### PR TITLE
Splitting the data-types module into two: `domain` and `application`- Onion

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.fraktalio.fmodel</groupId>
+        <artifactId>fmodel</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>application</artifactId>
+    <packaging>jar</packaging>
+    <name>fmodel-application</name>
+    <description>Functional Domain Modeling - Application</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fraktalio.fmodel</groupId>
+            <artifactId>domain</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.arrow-kt</groupId>
+            <artifactId>arrow-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/AggregateEventRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/AggregateEventRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import arrow.core.Either
+import arrow.core.computations.either
+
+/**
+ * Event repository interface
+ *
+ * @param C Command
+ * @param E Event
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface AggregateEventRepository<C, E> {
+    suspend fun C.fetchEvents(): Either<Error.FetchingEventsFailed, Iterable<E>>
+    suspend fun E.save(): Either<Error.StoringEventFailed<E>, Success.EventStoredSuccessfully<E>>
+    suspend fun Iterable<E>.save(): Either<Error.StoringEventFailed<E>, Iterable<Success.EventStoredSuccessfully<E>>> =
+        either { map { it.save().bind() } }
+}

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/AggregateStateRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/AggregateStateRepository.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import arrow.core.Either
+import arrow.core.computations.either
+
+/**
+ * Aggregate state repository interface.
+ *
+ * Used by StateStoredAggregate
+ *
+ * @param C Command
+ * @param S State
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface AggregateStateRepository<C, S> {
+    suspend fun C.fetchState(): Either<Error.FetchingStateFailed, S?>
+    suspend fun S.save(): Either<Error.StoringStateFailed<S>, Success.StateStoredSuccessfully<S>>
+    suspend fun List<S>.save(): Either<Error.StoringStateFailed<S>, Iterable<Success.StateStoredSuccessfully<S>>> =
+        either { map { it.save().bind() } }
+}

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
@@ -14,33 +14,33 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.application
 
 import arrow.core.Either
 import arrow.core.computations.either
+import com.fraktalio.fmodel.domain.Decider
 
 /**
  * Event sourcing aggregate is using/delegating a [Decider] to handle commands and produce events.
- * In order to handle the command, aggregate needs to fetch the current state (represented as a list of events) via [fetchEvents] function, and then delegate the command to the decider which can produce event(s) as a result.
- * Produced events are then stored via [storeEvents] suspending function.
- * It is the responsibility of the user to implement these functions [fetchEvents] and [storeEvents] per need.
- * These two functions are producing side effects (infrastructure), and they are deliberately separated from the decider (pure domain logic).
+ * In order to handle the command, aggregate needs to fetch the current state (represented as a list of events) via [AggregateEventRepository.fetchEvents] function, and then delegate the command to the decider which can produce new event(s) as a result.
+ * Produced events are then stored via [AggregateEventRepository.save] suspending function.
+ *
+ * [EventSourcingAggregate] implements an interface [AggregateEventRepository] by delegating all of its public members to a specified object.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that this aggregate can publish
  * @property decider A decider component of type [Decider]<[C], [S], [E]>.
- * @property storeEvents A suspending function that takes the newly produced events by [Decider] and stores them (produces side effect by modifying object/data outside its own scope) by resulting with [either] error [Error.StoringEventsFailed] or success [Success.EventsStoredSuccessfully]
- * @property fetchEvents A suspending function that takes the command of type [C] and results with [either] error [Error.FetchingEventsFailed] or success [Iterable]<[E]>
+ * @property aggregateEventRepository Interface for [E]vent management/persistence - dependencies by delegation
  * @constructor Creates [EventSourcingAggregate]
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 data class EventSourcingAggregate<C, S, E>(
-    val decider: Decider<C, S, E>,
-    val storeEvents: suspend (Iterable<E>) -> Either<Error.StoringEventsFailed<E>, Success.EventsStoredSuccessfully<E>>,
-    val fetchEvents: suspend (C) -> Either<Error.FetchingEventsFailed, Iterable<E>>
-) {
+    private val decider: Decider<C, S, E>,
+    private val aggregateEventRepository: AggregateEventRepository<C, E>
+) : AggregateEventRepository<C, E> by aggregateEventRepository {
 
     /**
      * Handles the command message of type [C]
@@ -48,29 +48,17 @@ data class EventSourcingAggregate<C, S, E>(
      * @param command Command message of type [C]
      * @return Either [Error] or [Success]
      */
-    suspend fun handle(command: C): Either<Error, Success> =
+    suspend fun handle(command: C): Either<Error, Iterable<Success.EventStoredSuccessfully<E>>> =
         // Arrow provides a Monad instance for Either. Except for the types signatures, our program remains unchanged when we compute over Either. All values on the left side assume to be Right biased and, whenever a Left value is found, the computation short-circuits, producing a result that is compatible with the function type signature.
         either {
-            val events = fetchEvents(command).bind()
+            val events = command.fetchEvents().bind()
             val state: S = validate(events.fold(decider.initialState, decider.evolve)).bind()
             val newEvents = decider.decide(command, state)
-            storeEvents(newEvents).bind()
+            newEvents.save().bind()
         }
 
     private fun validate(state: S): Either<Error, S> =
         if (decider.isTerminal(state)) Either.Left(Error.AggregateIsInTerminalState(state))
         else Either.Right(state)
 
-    /**
-     * Left map over C (Command) - Contravariant
-     *
-     * @param Cn Command new
-     * @param f
-     */
-    inline fun <Cn> lmapOnC(crossinline f: (Cn) -> C): EventSourcingAggregate<Cn, S, E> =
-        EventSourcingAggregate(
-            storeEvents = { e -> this.storeEvents(e) },
-            fetchEvents = { c -> this.fetchEvents(f(c)) },
-            decider = this.decider.lmapOnC(f)
-        )
 }

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/ProcessManager.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/ProcessManager.kt
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.application
 
 import arrow.core.Either
 import arrow.core.computations.either
+import com.fraktalio.fmodel.domain.Process
 
 /**
  * Process manager pattern is a durable event scheduler that encapsulates process specific logic and maintain a central point of control deciding what to execute next ([A]) once a process is completed.

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/Result.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/Result.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.application
 
 /**
  * A general result of any operation
@@ -35,6 +35,7 @@ sealed class Result
 sealed class Error : Result() {
     data class FetchingStateFailed(val throwable: Throwable?) : Error()
     data class FetchingEventsFailed(val throwable: Throwable?) : Error()
+    data class StoringEventFailed<E>(val event: E, val throwable: Throwable?) : Error()
     data class StoringEventsFailed<E>(val event: Iterable<E>, val throwable: Throwable?) : Error()
     data class StoringStateFailed<S>(val state: S, val throwable: Throwable?) : Error()
     data class AggregateIsInTerminalState<S>(val state: S) : Error()
@@ -58,9 +59,12 @@ sealed class Error : Result() {
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 sealed class Success : Result() {
+    data class EventStoredSuccessfully<E>(val event: E) : Success()
     data class EventsStoredSuccessfully<E>(val event: Iterable<E>) : Success()
     data class StateStoredSuccessfully<S>(val state: S) : Success()
-    data class StateStoredAndEventsPublishedSuccessfully<S, E>(val state: S, val event: Iterable<E>) : Success()
+    data class StateStoredAndEventsPublishedSuccessfully<S, E>(val state: S, val event: Iterable<E> = emptyList()) :
+        Success()
+
     data class ActionsPublishedAndStateStoredSuccessfully<S, A>(val state: S, val action: Iterable<A>) : Success()
     data class ActionsPublishedSuccessfully<A>(val action: Iterable<A>) : Success()
 

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/SagaManager.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/SagaManager.kt
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.application
 
 import arrow.core.Either
 import arrow.core.computations.either
+import com.fraktalio.fmodel.domain.Saga
 
 /**
  * Saga manager - Stateless process orchestrator

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/ViewStateRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/ViewStateRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import arrow.core.Either
+import arrow.core.computations.either
+
+/**
+ * View state repository interface
+ *
+ * @param E Event
+ * @param S State
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface ViewStateRepository<E, S> {
+    suspend fun E.fetchState(): Either<Error.FetchingStateFailed, S?>
+    suspend fun S.save(): Either<Error.StoringStateFailed<S>, Success.StateStoredSuccessfully<S>>
+    suspend fun List<S>.save(): Either<Error.StoringStateFailed<S>, Iterable<Success.StateStoredSuccessfully<S>>> =
+        either { map { it.save().bind() } }
+}

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -25,10 +25,10 @@
         <version>1.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>data-types</artifactId>
+    <artifactId>domain</artifactId>
     <packaging>jar</packaging>
-    <name>fmodel data-types</name>
-    <description>Functional Domain Modeling - Datatypes</description>
+    <name>fmodel-domain</name>
+    <description>Functional Domain Modeling - Domain - Core</description>
 
     <dependencies>
         <dependency>
@@ -36,13 +36,8 @@
             <artifactId>kotlin-stdlib-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.arrow-kt</groupId>
             <artifactId>arrow-core</artifactId>
         </dependency>
-
     </dependencies>
 </project>

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Decider.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Decider.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.domain
 
 import arrow.core.Either
 import arrow.core.identity
@@ -167,8 +167,6 @@ data class _Decider<C, Si, So, Ei, Eo>(
         initialState = so,
         isTerminal = { si -> true }
     )
-
-
 }
 
 

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Process.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Process.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.domain
 
 /**
  * [_Process] is a datatype that represents the central point of control deciding what to execute next ([A]).

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.domain
 
 /**
  * [_Saga] is a datatype that represents the central point of control deciding what to execute next ([A]).

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.fraktalio.fmodel.datatypes
+package com.fraktalio.fmodel.domain
 
 import arrow.core.Either
 import arrow.core.identity

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,6 @@ These examples are demonstrating the usage of the `fmodel` libraries to model a 
 ### Plain Kotlin - command line applications
  - [ApplicationEventSourcedEvenNumbers](src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/ApplicationEventSourcedEvenNumbers.kt) - Adding and subtracting **even** numbers
  - [ApplicationEventSourcedOddNumbers](src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/ApplicationEventSourcedOddNumbers.kt) - Adding and subtracting **odd** numbers
- - [ApplicationEventSourcedNumbers](src/main/kotlin/com/fraktalio/fmodel/examples/numbers/ApplicationEventSourcedNumbers.kt) - Adding and subtracting **all** numbers by **composing even and odd deciders into one `bigger` decider**.
+ - [ApplicationEventSourcedNumbers](src/main/kotlin/com/fraktalio/fmodel/examples/numbers/ApplicationEventSourcedNumbers.kt) - Adding and subtracting **all** numbers by **composing even and odd deciders into one `bigger` decider for all numbers**.
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -32,7 +32,12 @@
     <dependencies>
         <dependency>
             <groupId>com.fraktalio.fmodel</groupId>
-            <artifactId>data-types</artifactId>
+            <artifactId>domain</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fraktalio.fmodel</groupId>
+            <artifactId>application</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/ApplicationEventSourcedNumbers.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/ApplicationEventSourcedNumbers.kt
@@ -20,63 +20,66 @@ import arrow.core.Either
 import com.fraktalio.fmodel.examples.numbers.api.Description
 import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
 import com.fraktalio.fmodel.examples.numbers.api.NumberValue
+import com.fraktalio.fmodel.examples.numbers.even.command.evenNumberDecider
+import com.fraktalio.fmodel.examples.numbers.even.query.evenNumberView
+import com.fraktalio.fmodel.examples.numbers.odd.command.oddNumberDecider
+import com.fraktalio.fmodel.examples.numbers.odd.query.oddNumberView
 import kotlinx.coroutines.runBlocking
 
 fun main(args: Array<String>) = runBlocking { // start main coroutine
 
-    println("  " + NUMBER_AGGREGATE.decider.initialState)
+    val eventSourcingAggregate = numberAggregate(evenNumberDecider(), oddNumberDecider(), numberRepository())
+    val materializedView = numberMaterializedView(oddNumberView(), evenNumberView(), NumberViewRepository())
 
     println(
-        NUMBER_AGGREGATE.handle(
+        eventSourcingAggregate.handle(
             Either.Right(
                 NumberCommand.OddNumberCommand.AddOddNumber(
                     Description("Add 1"),
                     NumberValue(1)
                 )
             )
-        )
+        ).map { it.map { eventStoredSuccessfully -> materializedView.handle(eventStoredSuccessfully.event) } }
     )
     println(
-        NUMBER_AGGREGATE.handle(
+        eventSourcingAggregate.handle(
             Either.Left(
                 NumberCommand.EvenNumberCommand.AddEvenNumber(
                     Description("Add 4"),
                     NumberValue(4)
                 )
             )
-        )
+        ).map { it.map { eventStoredSuccessfully -> materializedView.handle(eventStoredSuccessfully.event) } }
     )
     println(
-        NUMBER_AGGREGATE.handle(
+        eventSourcingAggregate.handle(
             Either.Right(
                 NumberCommand.OddNumberCommand.AddOddNumber(
                     Description("Add 3"),
                     NumberValue(3)
                 )
             )
-        )
+        ).map { it.map { eventStoredSuccessfully -> materializedView.handle(eventStoredSuccessfully.event) } }
     )
     println(
-        NUMBER_AGGREGATE.handle(
+        eventSourcingAggregate.handle(
             Either.Left(
                 NumberCommand.EvenNumberCommand.AddEvenNumber(
                     Description("Add 8"),
                     NumberValue(8)
                 )
             )
-        )
+        ).map { it.map { eventStoredSuccessfully -> materializedView.handle(eventStoredSuccessfully.event) } }
     )
     println(
-        NUMBER_AGGREGATE.handle(
+        eventSourcingAggregate.handle(
             Either.Left(
                 NumberCommand.EvenNumberCommand.SubtractEvenNumber(
                     Description("Subtract 2"),
                     NumberValue(2)
                 )
             )
-        )
+        ).map { it.map { eventStoredSuccessfully -> materializedView.handle(eventStoredSuccessfully.event) } }
     )
-
-    println("Events: $numberEventStorage")
 }
 

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberRepository.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
+import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple event store ;)  It is initially empty.
+ */
+private var numberEventStorage: List<NumberEvent?> = emptyList()
+private val numberEventStorageMutex = Mutex()
+
+/**
+ * Number (event) repository
+ *
+ * @constructor Creates Number repository
+ */
+class NumberRepository :
+    AggregateEventRepository<Either<NumberCommand.EvenNumberCommand?, NumberCommand.OddNumberCommand?>, Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>> {
+
+    override suspend fun Either<NumberCommand.EvenNumberCommand?, NumberCommand.OddNumberCommand?>.fetchEvents(): Either<Error.FetchingEventsFailed, Iterable<Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>>> =
+        Either.catch {
+            numberEventStorage.map { numberEvent ->
+                when (numberEvent) {
+                    is NumberEvent.EvenNumberEvent -> Either.Left(numberEvent)
+                    is NumberEvent.OddNumberEvent -> Either.Right(numberEvent)
+                    null -> throw UnsupportedOperationException("fetched null event from the event store")
+                }
+            }
+        }.mapLeft { throwable -> Error.FetchingEventsFailed(throwable) }
+
+
+    override suspend fun Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>.save(): Either<Error.StoringEventFailed<Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>>, Success.EventStoredSuccessfully<Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>>> =
+        Either.catch {
+            numberEventStorageMutex.withLock {
+                numberEventStorage = numberEventStorage.plus(
+                    when (this) {
+                        is Either.Left -> this.value
+                        is Either.Right -> this.value
+                    }
+                )
+            }
+            Success.EventStoredSuccessfully(this)
+        }.mapLeft { throwable -> Error.StoringEventFailed(this, throwable) }
+}
+
+/**
+ * Number repository
+ *
+ * @return Number repository instance
+ */
+fun numberRepository(): AggregateEventRepository<Either<NumberCommand.EvenNumberCommand?, NumberCommand.OddNumberCommand?>, Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>> =
+    NumberRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberRepository.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.examples.numbers
 
 import arrow.core.Either
 import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberViewRepository.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.examples.numbers.api.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple state store ;)  It is initially empty.
+ */
+var numberStateStorage1: EvenNumberState? = EvenNumberState(Description("0"), NumberValue(0))
+var numberStateStorage2: OddNumberState? = OddNumberState(Description("0"), NumberValue(0))
+private val numberStateStorageMutex = Mutex()
+
+/**
+ * Number (state) repository implementation
+ *
+ * @constructor Creates number repository
+ */
+class NumberViewRepository :
+    ViewStateRepository<Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>, Pair<EvenNumberState?, OddNumberState?>> {
+
+    override suspend fun Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>.fetchState(): Either<Error.FetchingStateFailed, Pair<EvenNumberState?, OddNumberState?>?> =
+
+        Either.catch {
+            when (this) {
+                is Either.Left -> Pair(numberStateStorage1, null)
+                is Either.Right -> Pair(null, numberStateStorage2)
+            }
+        }.mapLeft { throwable ->
+            Error.FetchingStateFailed(throwable)
+        }
+
+
+    override suspend fun Pair<EvenNumberState?, OddNumberState?>.save(): Either<Error.StoringStateFailed<Pair<EvenNumberState?, OddNumberState?>>, Success.StateStoredSuccessfully<Pair<EvenNumberState?, OddNumberState?>>> =
+
+        Either.catch {
+            numberStateStorageMutex.withLock {
+                when {
+                    this.first != null -> numberStateStorage1 = this.first
+                    this.second != null -> numberStateStorage2 = this.second
+                }
+
+            }
+            Success.StateStoredSuccessfully(this)
+        }.mapLeft { throwable ->
+            Error.StoringStateFailed(this, throwable)
+        }
+}
+
+/**
+ * Number state repository
+ *
+ * @return state repository instance for all numbers
+ */
+fun numberViewRepository(): ViewStateRepository<Either<NumberEvent.EvenNumberEvent?, NumberEvent.OddNumberEvent?>, Pair<EvenNumberState?, OddNumberState?>> =
+    NumberViewRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/NumberViewRepository.kt
@@ -17,6 +17,7 @@
 package com.fraktalio.fmodel.examples.numbers
 
 import arrow.core.Either
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.application.ViewStateRepository
 import com.fraktalio.fmodel.examples.numbers.api.*

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberDecider.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberDecider.kt
@@ -16,10 +16,15 @@
 
 package com.fraktalio.fmodel.examples.numbers.even.command
 
-import com.fraktalio.fmodel.datatypes.Decider
+import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.examples.numbers.api.*
 
-val EVEN_NUMBER_DECIDER: Decider<NumberCommand.EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?> =
+/**
+ * Even number decider - pure declaration of our program logic
+ *
+ * @return Even number decider instance
+ */
+fun evenNumberDecider(): Decider<NumberCommand.EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?> =
     Decider(
         isTerminal = { s -> s.value.get > 100 },
         initialState = EvenNumberState(Description("Initial state"), NumberValue(0)),

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberRepository.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers.even.command
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
+import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple event store ;)  It is initially empty.
+ */
+private var evenNumberEventStorage: List<NumberEvent.EvenNumberEvent?> = emptyList()
+private val evenNumberEventStorageMutex = Mutex()
+
+/**
+ * Even number repository implementation
+ *
+ * @constructor Creates Even number repository
+ */
+class EvenNumberRepository : AggregateEventRepository<NumberCommand.EvenNumberCommand?, NumberEvent.EvenNumberEvent?> {
+
+    override suspend fun NumberCommand.EvenNumberCommand?.fetchEvents(): Either<Error.FetchingEventsFailed, Iterable<NumberEvent.EvenNumberEvent?>> =
+        Either.catch {
+            evenNumberEventStorage
+        }.mapLeft { throwable -> Error.FetchingEventsFailed(throwable) }
+
+
+    override suspend fun NumberEvent.EvenNumberEvent?.save(): Either<Error.StoringEventFailed<NumberEvent.EvenNumberEvent?>, Success.EventStoredSuccessfully<NumberEvent.EvenNumberEvent?>> =
+        Either.catch {
+            evenNumberEventStorageMutex.withLock {
+                evenNumberEventStorage = evenNumberEventStorage.plus(this)
+            }
+            Success.EventStoredSuccessfully(this)
+        }.mapLeft { throwable -> Error.StoringEventFailed(this, throwable) }
+}
+
+/**
+ * Even number repository
+ *
+ * @return event repository instance for Even numbers
+ */
+fun evenNumberRepository(): AggregateEventRepository<NumberCommand.EvenNumberCommand?, NumberEvent.EvenNumberEvent?> =
+    EvenNumberRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/command/EvenNumberRepository.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.examples.numbers.even.command
 
 import arrow.core.Either
 import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberView.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberView.kt
@@ -16,14 +16,18 @@
 
 package com.fraktalio.fmodel.examples.numbers.even.query
 
-import com.fraktalio.fmodel.datatypes.View
+import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.examples.numbers.api.Description
 import com.fraktalio.fmodel.examples.numbers.api.EvenNumberState
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.examples.numbers.api.NumberValue
 
-
-val EVEN_NUMBER_VIEW: View<EvenNumberState?, NumberEvent.EvenNumberEvent?> = View(
+/**
+ * Even number view -  pure declaration of our program logic
+ *
+ * @return Even number view instance
+ */
+fun evenNumberView(): View<EvenNumberState?, NumberEvent.EvenNumberEvent?> = View(
     initialState = EvenNumberState(Description("Initial state"), NumberValue(0)),
     evolve = { evenNumberState, e ->
         when {

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberViewRepository.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers.even.query
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.examples.numbers.api.EvenNumberState
+import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple state store ;)  It is initially empty.
+ */
+private var evenNumberStateStorage: EvenNumberState? = null
+private val evenNumberStateStorageMutex = Mutex()
+
+/**
+ * Even number repository implementation
+ *
+ * @constructor Creates Even number repository
+ */
+class EvenNumberViewRepository : ViewStateRepository<NumberEvent.EvenNumberEvent?, EvenNumberState?> {
+
+    override suspend fun NumberEvent.EvenNumberEvent?.fetchState(): Either<Error.FetchingStateFailed, EvenNumberState?> =
+
+        Either.catch {
+            evenNumberStateStorage
+        }.mapLeft { throwable ->
+            Error.FetchingStateFailed(throwable)
+        }
+
+
+    override suspend fun EvenNumberState?.save(): Either<Error.StoringStateFailed<EvenNumberState?>, Success.StateStoredSuccessfully<EvenNumberState?>> =
+
+        Either.catch {
+            evenNumberStateStorageMutex.withLock {
+                evenNumberStateStorage = this
+            }
+            Success.StateStoredSuccessfully(this)
+        }.mapLeft { throwable ->
+            Error.StoringStateFailed(this, throwable)
+        }
+}
+
+/**
+ * Even number state repository
+ *
+ * @return state repository instance for Even numbers
+ */
+fun evenNumberViewRepository(): ViewStateRepository<NumberEvent.EvenNumberEvent?, EvenNumberState?> =
+    EvenNumberViewRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/even/query/EvenNumberViewRepository.kt
@@ -17,6 +17,7 @@
 package com.fraktalio.fmodel.examples.numbers.even.query
 
 import arrow.core.Either
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.application.ViewStateRepository
 import com.fraktalio.fmodel.examples.numbers.api.EvenNumberState

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberDecider.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberDecider.kt
@@ -16,11 +16,15 @@
 
 package com.fraktalio.fmodel.examples.numbers.odd.command
 
-import com.fraktalio.fmodel.datatypes.Decider
+import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.examples.numbers.api.*
 
-
-val ODD_NUMBER_DECIDER: Decider<NumberCommand.OddNumberCommand?, OddNumberState, NumberEvent.OddNumberEvent?> =
+/**
+ * Odd number decider - pure declaration of our program logic
+ *
+ * @return Odd number decider instance
+ */
+fun oddNumberDecider(): Decider<NumberCommand.OddNumberCommand?, OddNumberState, NumberEvent.OddNumberEvent?> =
     Decider(
         isTerminal = { s -> s.value.get > 100 },
         initialState = OddNumberState(Description("Initial state"), NumberValue(0)),

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberRepository.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers.odd.command
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
+import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple event store ;)  It is initially empty.
+ */
+private var oddNumberEventStorage: List<NumberEvent.OddNumberEvent?> = emptyList()
+private val oddNumberEventStorageMutex = Mutex()
+
+/**
+ * Odd number repository
+ *
+ * @constructor Creates Odd number repository
+ */
+class OddNumberRepository() : AggregateEventRepository<NumberCommand.OddNumberCommand?, NumberEvent.OddNumberEvent?> {
+
+    override suspend fun NumberCommand.OddNumberCommand?.fetchEvents(): Either<Error.FetchingEventsFailed, Iterable<NumberEvent.OddNumberEvent?>> =
+        Either.catch {
+            oddNumberEventStorage
+        }.mapLeft { throwable -> Error.FetchingEventsFailed(throwable) }
+
+
+    override suspend fun NumberEvent.OddNumberEvent?.save(): Either<Error.StoringEventFailed<NumberEvent.OddNumberEvent?>, Success.EventStoredSuccessfully<NumberEvent.OddNumberEvent?>> =
+        Either.catch {
+            oddNumberEventStorageMutex.withLock {
+                oddNumberEventStorage = oddNumberEventStorage.plus(this)
+            }
+            Success.EventStoredSuccessfully(this)
+        }.mapLeft { throwable -> Error.StoringEventFailed(this, throwable) }
+}
+
+/**
+ * Odd number repository
+ *
+ * @return Odd number repository instance
+ */
+fun oddNumberRepository(): AggregateEventRepository<NumberCommand.OddNumberCommand?, NumberEvent.OddNumberEvent?> =
+    OddNumberRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/command/OddNumberRepository.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.examples.numbers.odd.command
 
 import arrow.core.Either
 import com.fraktalio.fmodel.application.AggregateEventRepository
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.examples.numbers.api.NumberCommand
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberMaterializedView.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberMaterializedView.kt
@@ -16,43 +16,23 @@
 
 package com.fraktalio.fmodel.examples.numbers.odd.query
 
-import arrow.core.Either
-import com.fraktalio.fmodel.datatypes.Error
-import com.fraktalio.fmodel.datatypes.MaterializedView
-import com.fraktalio.fmodel.datatypes.Success
+import com.fraktalio.fmodel.application.MaterializedView
+import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.examples.numbers.api.OddNumberState
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-
 
 /**
- * Represents the state store for Odd numbers (it can be SQL table, NoSQL storage, ...)
+ * Odd number materialized view
+ *
+ * @param view pure declaration of our program logic
+ * @param repository Odd number repository
+ * @return Odd number materialized view
  */
-var oddNumberStateStorage: OddNumberState? = null
-val oddNumberStateStorageMutex = Mutex()
-
-/**
- * State stored view of the Odd Numbers
- */
-val ODD_NUMBER_MATERIALIZED_VIEW: MaterializedView<OddNumberState?, NumberEvent.OddNumberEvent?> = MaterializedView(
-    view = ODD_NUMBER_VIEW,
-    fetchState = {
-        Either.catch {
-            oddNumberStateStorage
-        }.mapLeft { throwable ->
-            Error.FetchingStateFailed(throwable)
-        }
-    },
-    storeState = {
-        Either.catch {
-            oddNumberStateStorageMutex.withLock {
-                oddNumberStateStorage = it
-            }
-            println("""= $oddNumberStateStorage""")
-            Success.StateStoredSuccessfully(it)
-        }.mapLeft { throwable ->
-            Error.StoringStateFailed(it, throwable)
-        }
-    }
+fun oddNumberMaterializedView(
+    view: View<OddNumberState?, NumberEvent.OddNumberEvent?>,
+    repository: ViewStateRepository<NumberEvent.OddNumberEvent?, OddNumberState?>
+): MaterializedView<OddNumberState?, NumberEvent.OddNumberEvent?> = MaterializedView(
+    view = view,
+    viewStateRepository = repository
 )

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberView.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberView.kt
@@ -16,14 +16,18 @@
 
 package com.fraktalio.fmodel.examples.numbers.odd.query
 
-import com.fraktalio.fmodel.datatypes.View
+import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.examples.numbers.api.Description
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.examples.numbers.api.NumberValue
 import com.fraktalio.fmodel.examples.numbers.api.OddNumberState
 
-
-val ODD_NUMBER_VIEW: View<OddNumberState?, NumberEvent.OddNumberEvent?> = View(
+/**
+ * Odd number view -  pure declaration of our program logic
+ *
+ * @return Odd number view instance
+ */
+fun oddNumberView(): View<OddNumberState?, NumberEvent.OddNumberEvent?> = View(
     initialState = OddNumberState(Description("Initial state"), NumberValue(0)),
     evolve = { oddNumberState, e ->
         when {

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberViewRepository.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.examples.numbers.odd.query
+
+import arrow.core.Either
+import com.fraktalio.fmodel.application.Success
+import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.examples.numbers.api.NumberEvent
+import com.fraktalio.fmodel.examples.numbers.api.OddNumberState
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * A very simple state store ;)  It is initially empty.
+ */
+private var oddNumberStateStorage: OddNumberState? = null
+private val oddNumberStateStorageMutex = Mutex()
+
+/**
+ * Odd number repository implementation
+ *
+ * @constructor Creates Odd number repository
+ */
+class OddNumberViewRepository : ViewStateRepository<NumberEvent.OddNumberEvent?, OddNumberState?> {
+
+    override suspend fun NumberEvent.OddNumberEvent?.fetchState(): Either<Error.FetchingStateFailed, OddNumberState?> =
+
+        Either.catch {
+            oddNumberStateStorage
+        }.mapLeft { throwable ->
+            Error.FetchingStateFailed(throwable)
+        }
+
+
+    override suspend fun OddNumberState?.save(): Either<Error.StoringStateFailed<OddNumberState?>, Success.StateStoredSuccessfully<OddNumberState?>> =
+
+        Either.catch {
+            oddNumberStateStorageMutex.withLock {
+                oddNumberStateStorage = this
+            }
+            Success.StateStoredSuccessfully(this)
+        }.mapLeft { throwable ->
+            Error.StoringStateFailed(this, throwable)
+        }
+
+
+}
+
+/**
+ * Odd number state repository
+ *
+ * @return state repository instance for Odd numbers
+ */
+fun oddNumberViewRepository(): ViewStateRepository<NumberEvent.OddNumberEvent?, OddNumberState?> =
+    OddNumberViewRepository()
+

--- a/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberViewRepository.kt
+++ b/examples/src/main/kotlin/com/fraktalio/fmodel/examples/numbers/odd/query/OddNumberViewRepository.kt
@@ -17,6 +17,7 @@
 package com.fraktalio.fmodel.examples.numbers.odd.query
 
 import arrow.core.Either
+import com.fraktalio.fmodel.application.Error
 import com.fraktalio.fmodel.application.Success
 import com.fraktalio.fmodel.application.ViewStateRepository
 import com.fraktalio.fmodel.examples.numbers.api.NumberEvent

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,8 @@
     </properties>
 
     <modules>
-        <module>data-types</module>
+        <module>domain</module>
+        <module>application</module>
         <module>examples</module>
     </modules>
 


### PR DESCRIPTION
NOTE: This is a major refactoring. 
API has been changed on the `application` layer/module

- Switching to delegation pattern [https://kotlinlang.org/docs/delegation.html](https://kotlinlang.org/docs/delegation.html)
- Improving the examples
- Improving the documentation (KDoc)

A huge step towards a release candidate.