### PR TITLE
Removed `suspend` from Domain signatures - Suspend conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ parameters:
 ```kotlin
 data class Decider<C, S, E>(
     val decide: (C, S) -> Flow<E>,
-    val evolve: suspend (S, E) -> S,
+    val evolve: (S, E) -> S,
 )
 ```
 
@@ -148,7 +148,7 @@ to the 3 generic parameters: `typealias Decider<C, S, E> = _Decider<C, S, S, E, 
 ```kotlin
 data class _Decider<C, Si, So, Ei, Eo>(
     val decide: (C, Si) -> Flow<Eo>,
-    val evolve: suspend (Si, Ei) -> So,
+    val evolve: (Si, Ei) -> So,
     val initialState: So
 )
 
@@ -255,7 +255,7 @@ to the 2 generic parameters: `typealias View<S, E> = _View<S, S, E>`
 
 ```kotlin
 data class _View<Si, So, E>(
-    val evolve: suspend (Si, E) -> So,
+    val evolve: (Si, E) -> So,
     val initialState: So,
 )
 
@@ -385,12 +385,13 @@ All `fmodel` components/libraries are released to [Maven Central](https://repo1.
 
 ### Examples
 
- - Envision how information system will look like and behave like by modeling the flow of information - [event modeling](https://eventmodeling.org/posts/what-is-event-modeling/)
- - The result is a blueprint of the overall solution
+- Envision how information system will look like and behave like by modeling the flow of information
+  - [event modeling](https://eventmodeling.org/posts/what-is-event-modeling/)
+- The result is a blueprint of the overall solution
 
 ![event-modeling](.assets/event-modeling.png)
 
- - Translate the blueprint into the [source code](https://github.com/fraktalio/fmodel-demos)
+- Translate the blueprint into the [source code](https://github.com/fraktalio/fmodel-demos)
 
 [https://github.com/fraktalio/fmodel-demos](https://github.com/fraktalio/fmodel-demos)
 

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
@@ -95,7 +95,7 @@ data class EventSourcingAggregate<C, S, E>(
 
 
     private suspend fun Flow<E>.calculateNewEvents(command: C): Flow<E> {
-        val currentState = fold(decider.initialState, decider.evolve)
+        val currentState = fold(decider.initialState) { s, e -> decider.evolve(s, e) }
         var resultingEvents = decider.decide(command, currentState)
 
         if (saga != null)

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
@@ -100,7 +100,7 @@ data class StateStoredAggregate<C, S, E>(
 
     private suspend fun S.calculateNewState(command: C): S {
         val events = decider.decide(command, this)
-        val newState = events.fold(this@calculateNewState, decider.evolve)
+        val newState = events.fold(this) { s, e -> decider.evolve(s, e) }
         if (saga != null) events.flatMapConcat { saga.react(it) }.collect { newState.calculateNewState(it) }
         return newState
     }

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
@@ -53,8 +53,8 @@ data class _Saga<AR, A>(
      * @param An
      * @param f
      */
-    inline fun <An> mapOnAction(crossinline f: suspend (A) -> An): _Saga<AR, An> = _Saga(
-        react = { ar -> this.react(ar).map(f) }
+    inline fun <An> mapOnAction(crossinline f: (A) -> An): _Saga<AR, An> = _Saga(
+        react = { ar -> this.react(ar).map { f(it) } }
     )
 
 }

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
@@ -37,7 +37,7 @@ package com.fraktalio.fmodel.domain
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 data class _View<Si, So, E>(
-    val evolve: suspend (Si, E) -> So,
+    val evolve: (Si, E) -> So,
     val initialState: So,
 ) {
     /**
@@ -92,8 +92,8 @@ data class _View<Si, So, E>(
      * @param ff
      */
     fun <Son> applyOnState(ff: _View<Si, (So) -> Son, E>): _View<Si, Son, E> = _View(
-        evolve = { si, e -> ff.evolve(si, e).invoke(this.evolve(si, e)) },
-        initialState = ff.initialState.invoke(this.initialState)
+        evolve = { si, e -> ff.evolve(si, e)(this.evolve(si, e)) },
+        initialState = ff.initialState(this.initialState)
     )
 
     /**


### PR DESCRIPTION
Utilizing conversion from regular functional types to suspending functional types (lambdas, function references).
Moving away from arbitrary expresions in favor of lambdas in the Domain module

 - https://youtrack.jetbrains.com/issue/KT-15917#focus=Comments-27-4175356.0-0
 - https://youtrack.jetbrains.com/issue/KT-43433

Kotlin is going to support `suspend conversions` fully including arbitrary expressions, in ver 1.6