### PR TITLE
Application module - Switching from Data Classes to Interfaces.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.fraktalio.fmodel</groupId>
         <artifactId>fmodel</artifactId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>application</artifactId>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.fraktalio.fmodel</groupId>
             <artifactId>domain</artifactId>
-            <version>2.1.2-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
@@ -16,6 +16,8 @@
 
 package com.fraktalio.fmodel.application
 
+import arrow.core.Either
+import com.fraktalio.fmodel.domain.Saga
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -46,3 +48,103 @@ interface ActionPublisher<A> {
     fun Flow<A>.publish(): Flow<A> =
         map { it.publish() }
 }
+
+/**
+ * Handle the Action Result of type [AR] and publish [Flow] of Actions of type [A] based on it.
+ * Usually, Action Results are Events, and Actions are Commands.
+ * But, it does not have to be like that. For example, an Action could be an HTTP Request to a third-party system.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [sagaManager] is used to create the object/instance of [SagaManager]<[AR], [A]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
+ * @param AR Action Result
+ * @param A Action
+ * @param actionResult Action Result represent the outcome of some action you want to handle in some way
+ * @param saga Saga component
+ * @return The flow of published actions - [Flow]<[A]>
+ */
+fun <P, AR, A> P.handle(
+    actionResult: AR,
+    saga: Saga<AR, A>
+): Flow<A> where P : ActionPublisher<A> =
+    actionResult.publishTo(sagaManager(saga, this))
+
+/**
+ * Handle the [Flow] of Action Results of type [AR] and publish [Flow] of Actions of type [A] based on it.
+ * Usually, Action Results are Events, and Actions are Commands.
+ * But, it does not have to be like that. For example, an Action could be an HTTP Request to a third-party system.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [sagaManager] is used to create the object/instance of [SagaManager]<[AR], [A]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
+ * @param AR Action Result
+ * @param A Action
+ * @param actionResults The flow of Action Results represent the outcome of some action you want to handle in some way
+ * @param saga Saga component
+ * @return The flow of published actions - [Flow]<[A]>
+ */
+fun <P, AR, A> P.handle(
+    actionResults: Flow<AR>,
+    saga: Saga<AR, A>
+): Flow<A> where P : ActionPublisher<A> =
+    actionResults.publishTo(sagaManager(saga, this))
+
+/**
+ * Handle the Action Result of type [AR] and publish [Flow] of [Either] Actions of type [A] or [Error].
+ * Usually, Action Results are Events, and Actions are Commands.
+ * But, it does not have to be like that. For example, an Action could be an HTTP Request to a third-party system.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [sagaManager] is used to create the object/instance of [SagaManager]<[AR], [A]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
+ * @param AR Action Result
+ * @param A Action
+ * @param actionResult Action Result represent the outcome of some action you want to handle in some way
+ * @param saga Saga component
+ * @return The flow of published actions - [Flow]<[Either]<[Error], [A]>>
+ */
+fun <P, AR, A> P.eitherHandleOrFail(
+    actionResult: AR,
+    saga: Saga<AR, A>
+): Flow<Either<Error, A>> where P : ActionPublisher<A> =
+    actionResult.publishEitherTo(sagaManager(saga, this))
+
+/**
+ * Handle the Action Result of type [AR] and publish [Flow] of [Either] Actions of type [A] or [Error].
+ * Usually, Action Results are Events, and Actions are Commands.
+ * But, it does not have to be like that. For example, an Action could be an HTTP Request to a third-party system.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [sagaManager] is used to create the object/instance of [SagaManager]<[AR], [A]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
+ * @param AR Action Result
+ * @param A Action
+ * @param actionResult Action Result represent the outcome of some action you want to handle in some way
+ * @param saga Saga component
+ * @return The flow of published actions - [Flow]<[Either]<[Error], [A]>>
+ */
+fun <P, AR, A> P.eitherHandleOrFail(
+    actionResult: Flow<AR>,
+    saga: Saga<AR, A>
+): Flow<Either<Error, A>> where P : ActionPublisher<A> =
+    actionResult.publishEitherTo(sagaManager(saga, this))

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/StateRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/StateRepository.kt
@@ -17,13 +17,14 @@
 package com.fraktalio.fmodel.application
 
 import arrow.core.Either
+import com.fraktalio.fmodel.domain.Decider
+import com.fraktalio.fmodel.domain.Saga
+import kotlinx.coroutines.flow.Flow
 
 /**
  * State repository interface.
  *
- * Used by [StateStoredAggregate]
- *
- * @param C Command / ActionResult
+ * @param C Command
  * @param S State
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
@@ -51,7 +52,7 @@ interface StateRepository<C, S> {
      * @receiver Command of type [C]
      * @return [Either] [Error] or the State of type [S]?
      */
-    suspend fun C.fetchStateEither(): Either<Error.FetchingStateFailed<C>, S?> =
+    suspend fun C.eitherFetchStateOrFail(): Either<Error.FetchingStateFailed<C>, S?> =
         Either.catch {
             fetchState()
         }.mapLeft { throwable -> Error.FetchingStateFailed(this, throwable) }
@@ -62,10 +63,134 @@ interface StateRepository<C, S> {
      * @receiver State of type [S]
      * @return [Either] [Error] or the newly saved State of type [S]
      */
-    suspend fun S.saveEither(): Either<Error.StoringStateFailed<S>, S> =
+    suspend fun S.eitherSaveOrFail(): Either<Error.StoringStateFailed<S>, S> =
         Either.catch {
             this.save()
         }.mapLeft { throwable -> Error.StoringStateFailed(this, throwable) }
-
-
 }
+
+/**
+ * Handle the command of type [C],
+ * compute the new state of type [S] based on the current/fetched state and the command being handled,
+ * and save new state.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
+ * @param C Commands of type [C] that this [decider] can handle
+ * @param S State of type [S]
+ * @param E Events of type [E] that are used internally by [decider] to build/fold new state
+ * @param command The command being handled
+ * @param decider The decider to compute new state
+ * @param saga Optional saga to orchestrate the computation of the new state
+ * @return The persisted, new state
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+suspend fun <R, C, S, E> R.handle(
+    command: C,
+    decider: Decider<C, S, E>,
+    saga: Saga<E, C>? = null
+): S where R : StateRepository<C, S> =
+    if (saga == null) command.publishTo(stateStoredAggregate(decider, this))
+    else command.publishTo(stateStoredOrchestratingAggregate(decider, this, saga))
+
+/**
+ * Handle the command of type [C],
+ * compute the new state of type [S] based on the current/fetched state and the command being handled,
+ * and save new state / [Either.isRight], or fail transparently by returning [Error] / [Either.isLeft].
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
+ * @param C Commands of type [C] that this [decider] can handle
+ * @param S State of type [S]
+ * @param E Events of type [E] that are used internally by [decider] to build/fold new state
+ * @param command The command being handled
+ * @param decider The decider to compute new state
+ * @param saga Optional saga to orchestrate the computation of the new state
+ * @return The persisted, new state
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+suspend fun <R, C, S, E> R.eitherHandleOrFail(
+    command: C,
+    decider: Decider<C, S, E>,
+    saga: Saga<E, C>? = null
+): Either<Error, S> where R : StateRepository<C, S> =
+    if (saga == null) command.publishEitherTo(stateStoredAggregate(decider, this))
+    else command.publishEitherTo(stateStoredOrchestratingAggregate(decider, this, saga))
+
+/**
+ * Handle the commands of type [Flow]<[C]>,
+ * compute the new state of type [S] based on the current/fetched state and the command being handled,
+ * and save new state.
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
+ * @param C Commands of type [C] that this [decider] can handle
+ * @param S State of type [S]
+ * @param E Events of type [E] that are used internally by [decider] to build/fold new state
+ * @param commands The commands being handled
+ * @param decider The decider to compute new state
+ * @param saga Optional saga to orchestrate the computation of the new state
+ * @return The persisted, new state as a [Flow]<[S]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <R, C, S, E> R.handle(
+    commands: Flow<C>,
+    decider: Decider<C, S, E>,
+    saga: Saga<E, C>? = null
+): Flow<S> where R : StateRepository<C, S> =
+    if (saga == null) commands.publishTo(stateStoredAggregate(decider, this))
+    else commands.publishTo(stateStoredOrchestratingAggregate(decider, this, saga))
+
+/**
+ * Handle the command of type [Flow]<[C]>,
+ * compute the new state of type [S] based on the current/fetched state and the command being handled,
+ * and save new state / [Either.isRight],
+ * or fail transparently by returning [Error] / [Either.isLeft]
+ * within a flow [Flow]<[Either]<[Error], [S]>>
+ *
+ * Dependency injection
+ * ____________________
+ * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ * Kotlin natively supports dependency injection with receivers.
+ * -------------------
+ *
+ * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
+ * @param C Commands of type [C] that this [decider] can handle
+ * @param S State of type [S]
+ * @param E Events of type [E] that are used internally by [decider] to build/fold new state
+ * @param commands The commands being handled
+ * @param decider The decider to compute new state
+ * @param saga Optional saga to orchestrate the computation of the new state
+ * @return The persisted, new state - [Flow]<[Either]<[Error], [S]>>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <R, C, S, E> R.eitherHandleOrFail(
+    commands: Flow<C>,
+    decider: Decider<C, S, E>,
+    saga: Saga<E, C>? = null
+): Flow<Either<Error, S>> where R : StateRepository<C, S> =
+    if (saga == null) commands.publishEitherTo(stateStoredAggregate(decider, this))
+    else commands.publishEitherTo(stateStoredOrchestratingAggregate(decider, this, saga))

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/AggregateTest.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/AggregateTest.kt
@@ -76,6 +76,29 @@ object AggregateTest : Spek({
             }
         }
 
+        Scenario("Success - Repo") {
+            lateinit var result: Flow<Either<Error, EvenNumberEvent?>>
+
+            When("handling command of type AddEvenNumber") {
+                runBlockingTest {
+                    result = evenNumberRepository().eitherHandleOrFail(
+                        AddEvenNumber(
+                            Description("Add 2"),
+                            NumberValue(2)
+                        ),
+                        evenNumberDecider()
+                    )
+                }
+            }
+            Then("expect success") {
+                runBlockingTest {
+                    result.take(1).collect {
+                        assert(it is Either.Right && it.value is EvenNumberEvent.EvenNumberAdded)
+                    }
+                }
+            }
+        }
+
         Scenario("Success - All Numbers Aggregate -  Even") {
             lateinit var result: Flow<Either<Error, NumberEvent?>>
 

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
@@ -42,6 +42,9 @@ import kotlin.test.assertTrue
 object StateStoredAggregateTest : Spek({
 
     Feature("Aggregate") {
+        val evenNumberStateRepository by memoized {
+            evenNumberStateRepository()
+        }
         val evenAggregate by memoized {
             evenNumberStateStoredAggregate(
                 evenNumberDecider(),
@@ -79,6 +82,28 @@ object StateStoredAggregateTest : Spek({
             }
         }
 
+        Scenario("Success - Repo -  Either") {
+            lateinit var result: Either<Error, EvenNumberState>
+
+            When("handling command of type AddEvenNumber") {
+                runBlockingTest {
+
+                    result = evenNumberStateRepository.eitherHandleOrFail(
+                        AddEvenNumber(
+                            Description("Add 2"),
+                            NumberValue(2)
+                        ),
+                        evenNumberDecider()
+                    )
+                }
+            }
+            Then("expect success") {
+                runBlockingTest {
+                    assert(result is Either.Right)
+                }
+            }
+        }
+
         Scenario("Success") {
             lateinit var result: EvenNumberState
 
@@ -90,6 +115,32 @@ object StateStoredAggregateTest : Spek({
                             Description("Add 2"),
                             NumberValue(2)
                         )
+                    )
+                }
+            }
+            Then("expect success") {
+                runBlockingTest {
+                    assertEquals(
+                        EvenNumberState(Description("Add 2"), NumberValue(2)),
+                        result
+                    )
+                }
+            }
+        }
+
+
+        Scenario("Success - Repo") {
+            lateinit var result: EvenNumberState
+
+            When("handling command of type AddEvenNumber") {
+                runBlockingTest {
+                    (evenNumberStateRepository() as EvenNumberStateRepository).deleteAll()
+                    result = evenNumberStateRepository.handle(
+                        AddEvenNumber(
+                            Description("Add 2"),
+                            NumberValue(2)
+                        ),
+                        evenNumberDecider()
                     )
                 }
             }

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
@@ -17,7 +17,7 @@
 package com.fraktalio.fmodel.application.examples.numbers
 
 import com.fraktalio.fmodel.application.EventRepository
-import com.fraktalio.fmodel.application.EventSourcingAggregate
+import com.fraktalio.fmodel.application.eventSourcingOrchestratingAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.Saga
 import com.fraktalio.fmodel.domain.combine
@@ -48,7 +48,7 @@ fun numberAggregate(
     repository: EventRepository<NumberCommand?, NumberEvent?>
 ) =
 
-    EventSourcingAggregate(
+    eventSourcingOrchestratingAggregate(
         decider = evenNumberDecider.combine(oddNumberDecider),
         eventRepository = repository,
         saga = evenNumberSaga.combine(oddNumberSaga)

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberMaterializedView.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberMaterializedView.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers
 
 import com.fraktalio.fmodel.application.MaterializedView
 import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.application.materializedView
 import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.domain.combine
 import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
@@ -42,7 +43,7 @@ fun numberMaterializedView(
     evenView: View<EvenNumberState?, EvenNumberEvent?>,
     repository: ViewStateRepository<NumberEvent?, Pair<EvenNumberState?, OddNumberState?>>
 ): MaterializedView<Pair<EvenNumberState?, OddNumberState?>, NumberEvent?> =
-    MaterializedView(
+    materializedView(
         view = evenView.combine(oddView),
         viewStateRepository = repository
     )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
@@ -17,7 +17,7 @@
 package com.fraktalio.fmodel.application.examples.numbers
 
 import com.fraktalio.fmodel.application.StateRepository
-import com.fraktalio.fmodel.application.StateStoredAggregate
+import com.fraktalio.fmodel.application.stateStoredOrchestratingAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.Saga
 import com.fraktalio.fmodel.domain.combine
@@ -47,7 +47,7 @@ fun numberStateStoredAggregate(
     oddNumberSaga: Saga<OddNumberEvent?, EvenNumberCommand>,
     repository: StateRepository<NumberCommand?, Pair<EvenNumberState, OddNumberState>>
 ) =
-    StateStoredAggregate(
+    stateStoredOrchestratingAggregate(
         decider = evenNumberDecider.combine(oddNumberDecider),
         stateRepository = repository,
         saga = evenNumberSaga.combine(oddNumberSaga)

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberEventSourcedAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberEventSourcedAggregate.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.even.command
 
 import com.fraktalio.fmodel.application.EventRepository
 import com.fraktalio.fmodel.application.EventSourcingAggregate
+import com.fraktalio.fmodel.application.eventSourcingAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand
@@ -36,7 +37,7 @@ fun evenNumberAggregate(
     repository: EventRepository<EvenNumberCommand?, NumberEvent.EvenNumberEvent?>
 ): EventSourcingAggregate<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?> =
 
-    EventSourcingAggregate(
+    eventSourcingAggregate(
         decider = decider,
         eventRepository = repository
     )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberStateStoredAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberStateStoredAggregate.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.even.command
 
 import com.fraktalio.fmodel.application.StateRepository
 import com.fraktalio.fmodel.application.StateStoredAggregate
+import com.fraktalio.fmodel.application.stateStoredAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand
@@ -36,7 +37,7 @@ fun evenNumberStateStoredAggregate(
     repository: StateRepository<EvenNumberCommand?, EvenNumberState>
 ): StateStoredAggregate<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?> =
 
-    StateStoredAggregate(
+    stateStoredAggregate(
         decider = decider,
         stateRepository = repository
     )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/query/EvenNumberMaterializedView.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/query/EvenNumberMaterializedView.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.even.query
 
 import com.fraktalio.fmodel.application.MaterializedView
 import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.application.materializedView
 import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEvent
@@ -32,7 +33,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEv
 fun evenNumberMaterializedView(
     view: View<EvenNumberState?, EvenNumberEvent?>,
     repository: ViewStateRepository<EvenNumberEvent?, EvenNumberState?>
-): MaterializedView<EvenNumberState?, EvenNumberEvent?> = MaterializedView(
+): MaterializedView<EvenNumberState?, EvenNumberEvent?> = materializedView(
     view = view,
     viewStateRepository = repository
 )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/command/OddNumberEventSourcedAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/command/OddNumberEventSourcedAggregate.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.odd.command
 
 import com.fraktalio.fmodel.application.EventRepository
 import com.fraktalio.fmodel.application.EventSourcingAggregate
+import com.fraktalio.fmodel.application.eventSourcingAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberCommand
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
@@ -35,7 +36,7 @@ fun oddNumberAggregate(
     repository: EventRepository<OddNumberCommand?, OddNumberEvent?>
 ): EventSourcingAggregate<OddNumberCommand?, OddNumberState, OddNumberEvent?> =
 
-    EventSourcingAggregate(
+    eventSourcingAggregate(
         decider = decider,
         eventRepository = repository
     )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/command/OddNumberStateStoredAggregate.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/command/OddNumberStateStoredAggregate.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.odd.command
 
 import com.fraktalio.fmodel.application.StateRepository
 import com.fraktalio.fmodel.application.StateStoredAggregate
+import com.fraktalio.fmodel.application.stateStoredAggregate
 import com.fraktalio.fmodel.domain.Decider
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberCommand
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
@@ -36,7 +37,7 @@ fun oddNumberStateStoredAggregate(
     repository: StateRepository<OddNumberCommand?, OddNumberState>
 ): StateStoredAggregate<OddNumberCommand?, OddNumberState, OddNumberEvent?> =
 
-    StateStoredAggregate(
+    stateStoredAggregate(
         decider = decider,
         stateRepository = repository
     )

--- a/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/query/OddNumberMaterializedView.kt
+++ b/application/src/test/kotlin/com/fraktalio/fmodel/application/examples/numbers/odd/query/OddNumberMaterializedView.kt
@@ -18,6 +18,7 @@ package com.fraktalio.fmodel.application.examples.numbers.odd.query
 
 import com.fraktalio.fmodel.application.MaterializedView
 import com.fraktalio.fmodel.application.ViewStateRepository
+import com.fraktalio.fmodel.application.materializedView
 import com.fraktalio.fmodel.domain.View
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
@@ -32,7 +33,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 fun oddNumberMaterializedView(
     view: View<OddNumberState?, OddNumberEvent?>,
     repository: ViewStateRepository<OddNumberEvent?, OddNumberState?>
-): MaterializedView<OddNumberState?, OddNumberEvent?> = MaterializedView(
+): MaterializedView<OddNumberState?, OddNumberEvent?> = materializedView(
     view = view,
     viewStateRepository = repository
 )

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.fraktalio.fmodel</groupId>
         <artifactId>fmodel</artifactId>
-        <version>2.1.2-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>domain</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>com.fraktalio.fmodel</groupId>
     <artifactId>fmodel</artifactId>
-    <version>2.1.2-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>fmodel</name>


### PR DESCRIPTION
It is extendable, less opinionated, and enables native Kotlin dependency injection in a better way.

 - The interfaces have default behavior in place (implemented methods). It can be extended if truly needed.
 - Convenient factory methods are added, utilizing the `delegation pattern` natively in Kotlin:
```
fun <C, S, E> eventSourcingAggregate(
    decider: Decider<C, S, E>,
    eventRepository: EventRepository<C, E>
): EventSourcingAggregate<C, S, E> =
    object : EventSourcingAggregate<C, S, E>, EventRepository<C, E> by eventRepository {
        override val decider = decider
    }
```
- Kotlin Dependency Injection with receivers and delegation:
```
fun <R, C, S, E> R.handle(
    command: C,
    decider: Decider<C, S, E>,
    saga: Saga<E, C>? = null
): Flow<E> where R : EventRepository<C, E> =
    if (saga == null) command.publishTo(eventSourcingAggregate(decider, this))
    else command.publishTo(eventSourcingOrchestratingAggregate(decider, this, saga))
```

