### PR TITLE
Domain interfaces added: IDecider, IView, ISaga

### DIFF
--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
@@ -17,7 +17,7 @@
 package com.fraktalio.fmodel.application
 
 import arrow.core.Either
-import com.fraktalio.fmodel.domain.Saga
+import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -61,18 +61,16 @@ interface ActionPublisher<A> {
  * Kotlin natively supports dependency injection with receivers.
  * -------------------
  *
- * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
  * @param AR Action Result
  * @param A Action
  * @param actionResult Action Result represent the outcome of some action you want to handle in some way
- * @param saga Saga component
+ * @param saga ISaga component
  * @return The flow of published actions - [Flow]<[A]>
  */
-fun <P, AR, A> P.handle(
+fun <AR, A> ActionPublisher<A>.handle(
     actionResult: AR,
-    saga: Saga<AR, A>
-): Flow<A> where P : ActionPublisher<A> =
-    actionResult.publishTo(sagaManager(saga, this))
+    saga: ISaga<AR, A>
+): Flow<A> = actionResult.publishTo(sagaManager(saga, this))
 
 /**
  * Handle the [Flow] of Action Results of type [AR] and publish [Flow] of Actions of type [A] based on it.
@@ -86,18 +84,16 @@ fun <P, AR, A> P.handle(
  * Kotlin natively supports dependency injection with receivers.
  * -------------------
  *
- * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
  * @param AR Action Result
  * @param A Action
  * @param actionResults The flow of Action Results represent the outcome of some action you want to handle in some way
- * @param saga Saga component
+ * @param saga ISaga component
  * @return The flow of published actions - [Flow]<[A]>
  */
-fun <P, AR, A> P.handle(
+fun <AR, A> ActionPublisher<A>.handle(
     actionResults: Flow<AR>,
-    saga: Saga<AR, A>
-): Flow<A> where P : ActionPublisher<A> =
-    actionResults.publishTo(sagaManager(saga, this))
+    saga: ISaga<AR, A>
+): Flow<A> = actionResults.publishTo(sagaManager(saga, this))
 
 /**
  * Handle the Action Result of type [AR] and publish [Flow] of [Either] Actions of type [A] or [Error].
@@ -111,18 +107,16 @@ fun <P, AR, A> P.handle(
  * Kotlin natively supports dependency injection with receivers.
  * -------------------
  *
- * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
  * @param AR Action Result
  * @param A Action
  * @param actionResult Action Result represent the outcome of some action you want to handle in some way
- * @param saga Saga component
+ * @param saga ISaga component
  * @return The flow of published actions - [Flow]<[Either]<[Error], [A]>>
  */
-fun <P, AR, A> P.eitherHandleOrFail(
+fun <AR, A> ActionPublisher<A>.eitherHandleOrFail(
     actionResult: AR,
-    saga: Saga<AR, A>
-): Flow<Either<Error, A>> where P : ActionPublisher<A> =
-    actionResult.publishEitherTo(sagaManager(saga, this))
+    saga: ISaga<AR, A>
+): Flow<Either<Error, A>> = actionResult.publishEitherTo(sagaManager(saga, this))
 
 /**
  * Handle the Action Result of type [AR] and publish [Flow] of [Either] Actions of type [A] or [Error].
@@ -136,15 +130,13 @@ fun <P, AR, A> P.eitherHandleOrFail(
  * Kotlin natively supports dependency injection with receivers.
  * -------------------
  *
- * @param P The type of the publisher - [P] : [ActionPublisher]<[A]>
  * @param AR Action Result
  * @param A Action
  * @param actionResult Action Result represent the outcome of some action you want to handle in some way
- * @param saga Saga component
+ * @param saga ISaga component
  * @return The flow of published actions - [Flow]<[Either]<[Error], [A]>>
  */
-fun <P, AR, A> P.eitherHandleOrFail(
+fun <AR, A> ActionPublisher<A>.eitherHandleOrFail(
     actionResult: Flow<AR>,
-    saga: Saga<AR, A>
-): Flow<Either<Error, A>> where P : ActionPublisher<A> =
-    actionResult.publishEitherTo(sagaManager(saga, this))
+    saga: ISaga<AR, A>
+): Flow<Either<Error, A>> = actionResult.publishEitherTo(sagaManager(saga, this))

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/EventRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/EventRepository.kt
@@ -17,8 +17,8 @@
 package com.fraktalio.fmodel.application
 
 import arrow.core.Either
-import com.fraktalio.fmodel.domain.Decider
-import com.fraktalio.fmodel.domain.Saga
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -64,14 +64,6 @@ interface EventRepository<C, E> {
  * compute the new `flow of events` based on the current/fetched flow of events and the command being handled,
  * and save new events.
  *
- * Dependency injection
- * ____________________
- * Internally, the [eventSourcingAggregate] is used to create the object/instance of [EventSourcingAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [EventRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E]
@@ -82,11 +74,11 @@ interface EventRepository<C, E> {
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.handle(
+fun <C, S, E> EventRepository<C, E>.handle(
     command: C,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<E> where R : EventRepository<C, E> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<E> =
     if (saga == null) command.publishTo(eventSourcingAggregate(decider, this))
     else command.publishTo(eventSourcingOrchestratingAggregate(decider, this, saga))
 
@@ -96,14 +88,7 @@ fun <R, C, S, E> R.handle(
  * and save new events / [Either.isRight],
  * or fail transparently by returning [Error] / [Either.isLeft].
  *
- * Dependency injection
- * ____________________
- * Internally, the [eventSourcingAggregate] is used to create the object/instance of [EventSourcingAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
  *
- * @param R The type of the repository - [R] : [EventRepository]<[C], [E]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E]
@@ -114,11 +99,11 @@ fun <R, C, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.eitherHandleOrFail(
+fun <C, S, E> EventRepository<C, E>.eitherHandleOrFail(
     command: C,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<Either<Error, E>> where R : EventRepository<C, E> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<Either<Error, E>> =
     if (saga == null) command.publishEitherTo(eventSourcingAggregate(decider, this))
     else command.publishEitherTo(eventSourcingOrchestratingAggregate(decider, this, saga))
 
@@ -127,14 +112,7 @@ fun <R, C, S, E> R.eitherHandleOrFail(
  * compute the new `flow of events` based on the current/fetched flow of events and the command being handled,
  * and save new events.
  *
- * Dependency injection
- * ____________________
- * Internally, the [eventSourcingAggregate] is used to create the object/instance of [EventSourcingAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
  *
- * @param R The type of the repository - [R] : [EventRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E]
@@ -145,11 +123,11 @@ fun <R, C, S, E> R.eitherHandleOrFail(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.handle(
+fun <C, S, E> EventRepository<C, E>.handle(
     command: Flow<C>,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<E> where R : EventRepository<C, E> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<E> =
     if (saga == null) command.publishTo(eventSourcingAggregate(decider, this))
     else command.publishTo(eventSourcingOrchestratingAggregate(decider, this, saga))
 
@@ -159,14 +137,6 @@ fun <R, C, S, E> R.handle(
  * and save new events / [Either.isRight],
  * or fail transparently by returning [Error] / [Either.isLeft].
  *
- * Dependency injection
- * ____________________
- * Internally, the [eventSourcingAggregate] is used to create the object/instance of [EventSourcingAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [EventRepository]<[C], [E]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E]
@@ -177,10 +147,10 @@ fun <R, C, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.eitherHandleOrFail(
+fun <C, S, E> EventRepository<C, E>.eitherHandleOrFail(
     command: Flow<C>,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<Either<Error, E>> where R : EventRepository<C, E> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<Either<Error, E>> =
     if (saga == null) command.publishEitherTo(eventSourcingAggregate(decider, this))
     else command.publishEitherTo(eventSourcingOrchestratingAggregate(decider, this, saga))

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/StateRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/StateRepository.kt
@@ -17,8 +17,8 @@
 package com.fraktalio.fmodel.application
 
 import arrow.core.Either
-import com.fraktalio.fmodel.domain.Decider
-import com.fraktalio.fmodel.domain.Saga
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -74,14 +74,6 @@ interface StateRepository<C, S> {
  * compute the new state of type [S] based on the current/fetched state and the command being handled,
  * and save new state.
  *
- * Dependency injection
- * ____________________
- * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [decider] to build/fold new state
@@ -92,11 +84,11 @@ interface StateRepository<C, S> {
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-suspend fun <R, C, S, E> R.handle(
+suspend fun <C, S, E> StateRepository<C, S>.handle(
     command: C,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): S where R : StateRepository<C, S> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): S =
     if (saga == null) command.publishTo(stateStoredAggregate(decider, this))
     else command.publishTo(stateStoredOrchestratingAggregate(decider, this, saga))
 
@@ -105,14 +97,6 @@ suspend fun <R, C, S, E> R.handle(
  * compute the new state of type [S] based on the current/fetched state and the command being handled,
  * and save new state / [Either.isRight], or fail transparently by returning [Error] / [Either.isLeft].
  *
- * Dependency injection
- * ____________________
- * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [decider] to build/fold new state
@@ -123,11 +107,11 @@ suspend fun <R, C, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-suspend fun <R, C, S, E> R.eitherHandleOrFail(
+suspend fun <C, S, E> StateRepository<C, S>.eitherHandleOrFail(
     command: C,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Either<Error, S> where R : StateRepository<C, S> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Either<Error, S> =
     if (saga == null) command.publishEitherTo(stateStoredAggregate(decider, this))
     else command.publishEitherTo(stateStoredOrchestratingAggregate(decider, this, saga))
 
@@ -136,14 +120,6 @@ suspend fun <R, C, S, E> R.eitherHandleOrFail(
  * compute the new state of type [S] based on the current/fetched state and the command being handled,
  * and save new state.
  *
- * Dependency injection
- * ____________________
- * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [decider] to build/fold new state
@@ -154,11 +130,11 @@ suspend fun <R, C, S, E> R.eitherHandleOrFail(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.handle(
+fun <C, S, E> StateRepository<C, S>.handle(
     commands: Flow<C>,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<S> where R : StateRepository<C, S> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<S> =
     if (saga == null) commands.publishTo(stateStoredAggregate(decider, this))
     else commands.publishTo(stateStoredOrchestratingAggregate(decider, this, saga))
 
@@ -169,14 +145,6 @@ fun <R, C, S, E> R.handle(
  * or fail transparently by returning [Error] / [Either.isLeft]
  * within a flow [Flow]<[Either]<[Error], [S]>>
  *
- * Dependency injection
- * ____________________
- * Internally, the [stateStoredAggregate] is used to create the object/instance of [StateStoredAggregate]<[C], [S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [StateRepository]<[C], [S]>
  * @param C Commands of type [C] that this [decider] can handle
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [decider] to build/fold new state
@@ -187,10 +155,10 @@ fun <R, C, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, C, S, E> R.eitherHandleOrFail(
+fun <C, S, E> StateRepository<C, S>.eitherHandleOrFail(
     commands: Flow<C>,
-    decider: Decider<C, S, E>,
-    saga: Saga<E, C>? = null
-): Flow<Either<Error, S>> where R : StateRepository<C, S> =
+    decider: IDecider<C, S, E>,
+    saga: ISaga<E, C>? = null
+): Flow<Either<Error, S>> =
     if (saga == null) commands.publishEitherTo(stateStoredAggregate(decider, this))
     else commands.publishEitherTo(stateStoredOrchestratingAggregate(decider, this, saga))

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
@@ -18,27 +18,29 @@ package com.fraktalio.fmodel.application
 
 import arrow.core.Either
 import arrow.core.computations.either
-import com.fraktalio.fmodel.domain.Decider
-import com.fraktalio.fmodel.domain.Saga
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.flow.*
 
 /**
- * State stored aggregate is using a [StateStoredAggregate.decider] of type [Decider]<[C], [S], [E]> to handle commands and produce new state.
- * In order to handle the command, aggregate needs to fetch the current state via [StateRepository.fetchState] function first, and then delegate the command to the [StateStoredAggregate.decider] which can compute new state as a result.
+ * State stored aggregate is using/delegating a `decider` of type [IDecider]<[C], [S], [E]> to handle commands and produce new state.
+ * In order to handle the command, aggregate needs to fetch the current state via [StateRepository.fetchState] function first, and then delegate the command to the `decider` which can compute new state as a result.
  * New state is then stored via [StateRepository.save] suspending function.
  *
- * [StateStoredAggregate] implements an interface [StateRepository].
+ * [StateStoredAggregate] extends [IDecider] and [StateRepository] interfaces,
+ * clearly communicating that it is composed out of these two behaviours.
+ *
+ * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
+ * and Kotlin supports it natively requiring zero boilerplate code. [stateStoredAggregate] function is a good example.
+ *
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
- * @property decider A decider component of type [Decider]<[C], [S], [E]>.
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-interface StateStoredAggregate<C, S, E> : StateRepository<C, S> {
-    val decider: Decider<C, S, E>
-
+interface StateStoredAggregate<C, S, E> : IDecider<C, S, E>, StateRepository<C, S> {
     /**
      * Computes new State based on the previous State and the [command].
      *
@@ -46,8 +48,8 @@ interface StateStoredAggregate<C, S, E> : StateRepository<C, S> {
      * @return The newly computed state of type [S]
      */
     suspend fun S.computeNewState(command: C): S {
-        val events = decider.decide(command, this)
-        return events.fold(this) { s, e -> decider.evolve(s, e) }
+        val events = decide(command, this)
+        return events.fold(this) { s, e -> evolve(s, e) }
     }
 
     /**
@@ -70,7 +72,7 @@ interface StateStoredAggregate<C, S, E> : StateRepository<C, S> {
      * @return State of type [S]
      */
     suspend fun handle(command: C): S =
-        (command.fetchState() ?: decider.initialState)
+        (command.fetchState() ?: initialState)
             .computeNewState(command)
             .save()
 
@@ -92,7 +94,7 @@ interface StateStoredAggregate<C, S, E> : StateRepository<C, S> {
     suspend fun handleEither(command: C): Either<Error, S> =
         // Arrow provides a Monad instance for Either. Except for the types signatures, our program remains unchanged when we compute over Either. All values on the left side assume to be Right biased and, whenever a Left value is found, the computation short-circuits, producing a result that is compatible with the function type signature.
         either {
-            (command.eitherFetchStateOrFail().bind() ?: decider.initialState)
+            (command.eitherFetchStateOrFail().bind() ?: initialState)
                 .eitherComputeNewStateOrFail(command).bind()
                 .eitherSaveOrFail().bind()
         }
@@ -110,24 +112,25 @@ interface StateStoredAggregate<C, S, E> : StateRepository<C, S> {
 }
 
 /**
- * Orchestrating State stored aggregate is extending [StateStoredAggregate] by introducing [StateStoredOrchestratingAggregate.saga] property. It is using a [StateStoredAggregate.decider] of type [Decider]<[C], [S], [E]> to handle commands and produce new state.
- * In order to handle the command, aggregate needs to fetch the current state via [StateRepository.fetchState] function first, and then delegate the command to the [StateStoredAggregate.decider] which can compute new state as a result.
- * If the [StateStoredAggregate.decider] is combined out of many deciders via `combine` function, a [StateStoredOrchestratingAggregate.saga] could be used to react on new events and send new commands to the [StateStoredAggregate.decider] recursively, in one transaction.
+ * Orchestrating State stored aggregate is using/delegating a `decider` of type [IDecider]<[C], [S], [E]> to handle commands and produce new state.
+ * In order to handle the command, aggregate needs to fetch the current state via [StateRepository.fetchState] function first, and then delegate the command to the `decider` which can compute new state as a result.
+ * If the `decider` is combined out of many deciders via `combine` function, a `saga` could be used to react on new events and send new commands to the `decider` recursively, in single transaction.
  * New state is then stored via [StateRepository.save] suspending function.
  *
- * [StateStoredOrchestratingAggregate] extends interface [StateStoredAggregate].
+ * [StateStoredOrchestratingAggregate] extends [ISaga] and [StateStoredAggregate] interfaces,
+ * clearly communicating that it is composed out of these two behaviours.
+ *
+ * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
+ * and Kotlin supports it natively requiring zero boilerplate code. [stateStoredOrchestratingAggregate] function is a good example.
+ *
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
- * @property decider A decider component of type [Decider]<[C], [S], [E]>
- * @property saga A saga component of type [Saga]<[E], [C]>
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-interface StateStoredOrchestratingAggregate<C, S, E> : StateStoredAggregate<C, S, E> {
-    val saga: Saga<E, C>
-
+interface StateStoredOrchestratingAggregate<C, S, E> : ISaga<E, C>, StateStoredAggregate<C, S, E> {
     /**
      * Computes new State based on the previous State and the [command].
      *
@@ -135,9 +138,9 @@ interface StateStoredOrchestratingAggregate<C, S, E> : StateStoredAggregate<C, S
      * @return The newly computed state of type [S]
      */
     override suspend fun S.computeNewState(command: C): S {
-        val events = decider.decide(command, this)
-        val newState = events.fold(this) { s, e -> decider.evolve(s, e) }
-        events.flatMapConcat { saga.react(it) }.collect { newState.computeNewState(it) }
+        val events = decide(command, this)
+        val newState = events.fold(this) { s, e -> evolve(s, e) }
+        events.flatMapConcat { react(it) }.collect { newState.computeNewState(it) }
         return newState
     }
 }
@@ -150,22 +153,22 @@ interface StateStoredOrchestratingAggregate<C, S, E> : StateStoredAggregate<C, S
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
- * @param decider A decider component of type [Decider]<[C], [S], [E]>
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
  * @param stateRepository An aggregate state repository of type [StateRepository]<[C], [S]>
- * @param saga A saga component of type [Saga]<[E], [C]>
+ * @param saga A saga component of type [ISaga]<[E], [C]>
  * @return An object/instance of type [StateStoredOrchestratingAggregate]<[C], [S], [E]>
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 fun <C, S, E> stateStoredOrchestratingAggregate(
-    decider: Decider<C, S, E>,
+    decider: IDecider<C, S, E>,
     stateRepository: StateRepository<C, S>,
-    saga: Saga<E, C>
+    saga: ISaga<E, C>
 ): StateStoredOrchestratingAggregate<C, S, E> =
-    object : StateStoredOrchestratingAggregate<C, S, E>, StateRepository<C, S> by stateRepository {
-        override val decider = decider
-        override val saga = saga
-    }
+    object : StateStoredOrchestratingAggregate<C, S, E>,
+        StateRepository<C, S> by stateRepository,
+        IDecider<C, S, E> by decider,
+        ISaga<E, C> by saga {}
 
 /**
  * Extension function - State stored aggregate factory function.
@@ -175,19 +178,20 @@ fun <C, S, E> stateStoredOrchestratingAggregate(
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
- * @param decider A decider component of type [Decider]<[C], [S], [E]>
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
  * @param stateRepository An aggregate state repository of type [StateRepository]<[C], [S]>
  * @return An object/instance of type [StateStoredAggregate]<[C], [S], [E]>
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 fun <C, S, E> stateStoredAggregate(
-    decider: Decider<C, S, E>,
+    decider: IDecider<C, S, E>,
     stateRepository: StateRepository<C, S>
 ): StateStoredAggregate<C, S, E> =
-    object : StateStoredAggregate<C, S, E>, StateRepository<C, S> by stateRepository {
-        override val decider = decider
-    }
+    object :
+        StateStoredAggregate<C, S, E>,
+        StateRepository<C, S> by stateRepository,
+        IDecider<C, S, E> by decider {}
 
 
 /**

--- a/application/src/main/kotlin/com/fraktalio/fmodel/application/ViewStateRepository.kt
+++ b/application/src/main/kotlin/com/fraktalio/fmodel/application/ViewStateRepository.kt
@@ -17,11 +17,11 @@
 package com.fraktalio.fmodel.application
 
 import arrow.core.Either
-import com.fraktalio.fmodel.domain.View
+import com.fraktalio.fmodel.domain.IView
 import kotlinx.coroutines.flow.Flow
 
 /**
- * View state repository interface
+ * IView state repository interface
  *
  * Used by [MaterializedView]
  *
@@ -75,14 +75,6 @@ interface ViewStateRepository<E, S> {
  * compute the new state of type [S] based on the current/fetched state and the event being handled,
  * and save new state.
  *
- * Dependency injection
- * ____________________
- * Internally, the [materializedView] is used to create the object/instance of [MaterializedView]<[S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [ViewStateRepository]<[E], [S]>
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [view] to build/fold new state
  * @param event The event being handled
@@ -90,25 +82,16 @@ interface ViewStateRepository<E, S> {
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-suspend fun <R, S, E> R.handle(
+suspend fun <S, E> ViewStateRepository<E, S>.handle(
     event: E,
-    view: View<S, E>
-): S where R : ViewStateRepository<E, S> =
-    event.publishTo(materializedView(view, this))
+    view: IView<S, E>
+): S = event.publishTo(materializedView(view, this))
 
 /**
  * Handle events of type [E],
  * compute the new state of type [S] based on the current/fetched state and the event being handled,
  * and save new state.
  *
- * Dependency injection
- * ____________________
- * Internally, the [materializedView] is used to create the object/instance of [MaterializedView]<[S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [ViewStateRepository]<[E], [S]>
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [view] to build/fold new state
  * @param events The events being handled
@@ -116,25 +99,16 @@ suspend fun <R, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, S, E> R.handle(
+fun <S, E> ViewStateRepository<E, S>.handle(
     events: Flow<E>,
-    view: View<S, E>
-): Flow<S> where R : ViewStateRepository<E, S> =
-    events.publishTo(materializedView(view, this))
+    view: IView<S, E>
+): Flow<S> = events.publishTo(materializedView(view, this))
 
 /**
  * Handle events of type [E],
  * compute the new state of type [S] based on the current/fetched state and the event being handled,
  * and save new state / [Either.isRight], or fail transparently by returning [Error] / [Either.isLeft].
  *
- * Dependency injection
- * ____________________
- * Internally, the [materializedView] is used to create the object/instance of [MaterializedView]<[S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [ViewStateRepository]<[E], [S]>
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [view] to build/fold new state
  * @param event The event being handled
@@ -142,25 +116,16 @@ fun <R, S, E> R.handle(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-suspend fun <R, S, E> R.eitherHandleOrFail(
+suspend fun <S, E> ViewStateRepository<E, S>.eitherHandleOrFail(
     event: E,
-    view: View<S, E>
-): Either<Error, S> where R : ViewStateRepository<E, S> =
-    event.publishEitherTo(materializedView(view, this))
+    view: IView<S, E>
+): Either<Error, S> = event.publishEitherTo(materializedView(view, this))
 
 /**
  * Handle events of type [E],
  * compute the new state of type [S] based on the current/fetched state and the event being handled,
  * and save new state.
  *
- * Dependency injection
- * ____________________
- * Internally, the [materializedView] is used to create the object/instance of [MaterializedView]<[S], [E]>.
- * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
- * Kotlin natively supports dependency injection with receivers.
- * -------------------
- *
- * @param R The type of the repository - [R] : [ViewStateRepository]<[E], [S]>
  * @param S State of type [S]
  * @param E Events of type [E] that are used internally by [view] to build/fold new state
  * @param events The events being handled
@@ -168,8 +133,7 @@ suspend fun <R, S, E> R.eitherHandleOrFail(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-fun <R, S, E> R.eitherHandleOrFail(
+fun <S, E> ViewStateRepository<E, S>.eitherHandleOrFail(
     events: Flow<E>,
-    view: View<S, E>
-): Flow<S> where R : ViewStateRepository<E, S> =
-    events.publishTo(materializedView(view, this))
+    view: IView<S, E>
+): Flow<S> = events.publishTo(materializedView(view, this))

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Decider.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Decider.kt
@@ -21,6 +21,33 @@ import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
+/**
+ * An Interface of the [_Decider].
+ *
+ * @param C Command type - contravariant/in type parameter
+ * @param Si Input_State type - contravariant/in type parameter
+ * @param So Output_State type - covariant/out type parameter
+ * @param Ei Input_Event type - contravariant/in type parameter
+ * @param Eo Output_Event type - covariant/out type parameter
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface I_Decider<in C, in Si, out So, in Ei, out Eo> {
+    val decide: (C, Si) -> Flow<Eo>
+    val evolve: (Si, Ei) -> So
+    val initialState: So
+}
+
+/**
+ * A convenient typealias for the [I_Decider] interface. It is specializing the five parameters [I_Decider] interface to only three parameters interface [IDecider].
+ *
+ * `Si=So -> S`
+ * `Ei=Eo -> E`
+ * `C -> C`
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+typealias IDecider<C, S, E> = I_Decider<C, S, S, E, E>
 
 /**
  * [_Decider] is a datatype that represents the main decision-making algorithm.
@@ -43,10 +70,10 @@ import kotlinx.coroutines.flow.map
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 data class _Decider<in C, in Si, out So, in Ei, out Eo>(
-    val decide: (C, Si) -> Flow<Eo>,
-    val evolve: (Si, Ei) -> So,
-    val initialState: So
-) {
+    override val decide: (C, Si) -> Flow<Eo>,
+    override val evolve: (Si, Ei) -> So,
+    override val initialState: So
+) : I_Decider<C, Si, So, Ei, Eo> {
     /**
      * Left map on C/Command parameter - Contravariant
      *

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/Saga.kt
@@ -22,6 +22,20 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 /**
+ * An interface of the [_Saga].
+ *
+ * @param AR Action Result type
+ * @param A Action type
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface I_Saga<in AR, out A> {
+    val react: (AR) -> Flow<A>
+}
+
+typealias ISaga<AR, A> = I_Saga<AR, A>
+
+/**
  * [_Saga] is a datatype that represents the central point of control deciding what to execute next ([A]).
  * It is responsible for mapping different events into action results ([AR]) that the [_Saga] then can use to calculate the next actions ([A]) to be mapped to command(s).
  *
@@ -35,8 +49,8 @@ import kotlinx.coroutines.flow.map
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 data class _Saga<in AR, out A>(
-    val react: (AR) -> Flow<A>
-) {
+    override val react: (AR) -> Flow<A>
+) : I_Saga<AR, A> {
     /**
      * Left map on AR/ActionResult parameter - Contravariant
      *

--- a/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
+++ b/domain/src/main/kotlin/com/fraktalio/fmodel/domain/View.kt
@@ -17,6 +17,30 @@
 package com.fraktalio.fmodel.domain
 
 /**
+ * An interface of the [_View]
+ *
+ * @param Si Input_State type
+ * @param So Output_State type
+ * @param E Event type
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+interface I_View<in Si, out So, in E> {
+    val evolve: (Si, E) -> So
+    val initialState: So
+}
+
+/**
+ * A convenient typealias for the [I_View] interface. It is specializing the three parameters [I_View] interface to only two parameters interface [IView].
+ *
+ * `Si=So -> S`
+ * `E -> E`
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+typealias IView<S, E> = I_View<S, S, E>
+
+/**
  * [_View] is a datatype that represents the event handling algorithm,
  * responsible for translating the events into denormalized state,
  * which is more adequate for querying.
@@ -37,9 +61,9 @@ package com.fraktalio.fmodel.domain
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 data class _View<in Si, out So, in E>(
-    val evolve: (Si, E) -> So,
-    val initialState: So,
-) {
+    override val evolve: (Si, E) -> So,
+    override val initialState: So,
+) : I_View<Si, So, E> {
     /**
      * Left map on E/Event parameter - Contravariant
      *


### PR DESCRIPTION
By exposing a clear contract on the Domain layer we improved the Application layer interfaces. For example:

`EventSourcingAggregate` extends `IDecider` and `EventRepository` interfaces, clearly communicating that it is composed
out of these two behaviors.

The Delegation pattern has proven to be a good alternative to `implementation inheritance`, and Kotlin supports it
natively requiring zero boilerplate code.
`eventSourcingAggregate` function is a good example:

```kotlin
fun <C, S, E> eventSourcingAggregate(
    decider: IDecider<C, S, E>,
    eventRepository: EventRepository<C, E>
): EventSourcingAggregate<C, S, E> =
    object :
        EventSourcingAggregate<C, S, E>,
        EventRepository<C, E> by eventRepository,
        IDecider<C, S, E> by decider {}