### PR TITLE
Kotlin Actors (experimental) - concurrently handling messages

### DIFF
--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
@@ -1,0 +1,103 @@
+package com.fraktalio.fmodel.application
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.contracts.ExperimentalContracts
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Extension function - Handles the flow of command messages of type [C] by concurrently distributing the load across finite number of actors/handlers
+ *
+ * @param commands [Flow] of Command messages of type [C]
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @param partitionKey a function that calculates the partition key/routing key of command - commands with the same partition key will be handled wit the same actor to keep the ordering
+ * @return [Flow] of stored Events of type [E]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
+    commands: Flow<C>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (C) -> Int
+): Flow<E> = channelFlow {
+    val actors: List<SendChannel<C>> = (1..numberOfActors).map {
+        commandActor(channel, actorsCapacity, actorsStart, actorsContext) { command, channel ->
+            handle(command).collect { channel.send(it) }
+        }
+    }
+    commands
+        .onCompletion {
+            actors.forEach {
+                it.close()
+            }
+        }
+        .collect {
+            val partitionKeyVal = partitionKey(it)
+            val partition = (if (partitionKeyVal < 0) partitionKeyVal * (-1) else partitionKeyVal) % numberOfActors
+            actors[partition].send(it)
+        }
+}
+
+/**
+ * Extension function - Publishes [Flow] of commands of type [C] to the event sourcing aggregate of type  [EventSourcingAggregate]<[C], *, [E]> by concurrently distributing the load across finite number of actors
+ *
+ * @receiver [Flow] of commands of type [C]
+ * @param aggregate of type [EventSourcingAggregate]<[C], *, [E]>
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @param partitionKey a function that calculates the partition key/routing key of command - commands with the same partition key will be handled wit the same actor to keep the ordering
+ * @return the [Flow] of stored Events of type [E]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <C, E> Flow<C>.publishConcurrentlyTo(
+    aggregate: EventSourcingAggregate<C, *, E>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (C) -> Int
+): Flow<E> =
+    aggregate.handleConcurrently(this, numberOfActors, actorsCapacity, actorsStart, actorsContext) { partitionKey(it) }
+
+
+/**
+ * Command Actor - Event Sourced Aggregate
+ *
+ * @param fanInChannel A reference to the channel this coroutine/actor sends elements/events to
+ * @param handle A function that handles command and sends responses/events to [fanInChannel]
+ * @receiver CoroutineScope
+ */
+@ObsoleteCoroutinesApi
+private fun <C, E> CoroutineScope.commandActor(
+    fanInChannel: SendChannel<E>,
+    capacity: Int = Channel.RENDEZVOUS,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    context: CoroutineContext = EmptyCoroutineContext,
+    handle: suspend (C, SendChannel<E>) -> Unit
+) = actor<C>(context, capacity, start) {
+    for (msg in channel) {
+        handle(msg, fanInChannel)
+    }
+}

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.contracts.ExperimentalContracts
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+
+/**
+ * Extension function - Handles the flow of events of type [E] by concurrently distributing the load across finite number of actors/handlers
+ *
+ * @param events Flow of Events of type [E] to be handled
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return [Flow] of State of type [S]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <S, E> MaterializedView<S, E>.handleConcurrently(
+    events: Flow<E>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (E) -> Int
+): Flow<S> = channelFlow {
+    val actors: List<SendChannel<E>> = (1..numberOfActors).map {
+        eventActor(channel, actorsCapacity, actorsStart, actorsContext) { event, channel ->
+            channel.send(handle(event))
+        }
+    }
+    events
+        .onCompletion {
+            actors.forEach {
+                it.close()
+            }
+        }
+        .collect {
+            val partitionKeyVal = partitionKey(it)
+            val partition = (if (partitionKeyVal < 0) partitionKeyVal * (-1) else partitionKeyVal) % numberOfActors
+            actors[partition].send(it)
+        }
+}
+
+/**
+ * Extension function - Publishes the event of type [E] to the materialized view of type  [MaterializedView]<[S], [E]> by concurrently distributing the load across finite number of actors/handlers
+ *
+ * @receiver [Flow] of events of type [E]
+ * @param materializedView of type  [MaterializedView]<[S], [E]>
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return the [Flow] of stored State of type [S]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@FlowPreview
+@ExperimentalContracts
+fun <S, E> Flow<E>.publishConcurrentlyTo(
+    materializedView: MaterializedView<S, E>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (E) -> Int
+): Flow<S> =
+    materializedView.handleConcurrently(
+        this,
+        numberOfActors,
+        actorsCapacity,
+        actorsStart,
+        actorsContext
+    ) { partitionKey(it) }
+
+
+/**
+ * Event Actor - Materialized View
+ *
+ * @param fanInChannel A reference to the channel this coroutine/actor sends elements/state to
+ * @param handle A function that handles events and sends responses/state to [fanInChannel]
+ * @receiver CoroutineScope
+ */
+@ObsoleteCoroutinesApi
+private fun <E, S> CoroutineScope.eventActor(
+    fanInChannel: SendChannel<S>,
+    capacity: Int = Channel.RENDEZVOUS,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    context: CoroutineContext = EmptyCoroutineContext,
+    handle: suspend (E, SendChannel<S>) -> Unit
+) = actor<E>(context, capacity, start) {
+    for (msg in channel) {
+        handle(msg, fanInChannel)
+    }
+}

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.contracts.ExperimentalContracts
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Extension function - Handles the the [Flow] of action results of type [AR] by concurrently distributing the load across finite number of actors/handlers
+ *
+ * @param actionResults Action Results represent the outcome of some action you want to handle in some way
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return [Flow] of Actions of type [A]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <AR, A> SagaManager<AR, A>.handleConcurrently(
+    actionResults: Flow<AR>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (AR) -> Int
+): Flow<A> = channelFlow {
+    val actors: List<SendChannel<AR>> = (1..numberOfActors).map {
+        sagaActor(channel, actorsCapacity, actorsStart, actorsContext) { actionResult, channel ->
+            handle(actionResult).collect { channel.send(it) }
+        }
+    }
+    actionResults
+        .onCompletion {
+            actors.forEach {
+                it.close()
+            }
+        }
+        .collect {
+            val partitionKeyVal = partitionKey(it)
+            val partition = (if (partitionKeyVal < 0) partitionKeyVal * (-1) else partitionKeyVal) % numberOfActors
+            actors[partition].send(it)
+        }
+}
+
+/**
+ * Extension function - Publishes the action result of type [AR] to the saga manager of type  [SagaManager]<[AR], [A]> by concurrently distributing the load across finite number of actors/handlers
+ * @receiver [Flow] of action results of type [AR]
+ * @param sagaManager of type [SagaManager]<[AR], [A]>
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return the [Flow] of published Actions of type [A]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <AR, A> Flow<AR>.publishConcurrentlyTo(
+    sagaManager: SagaManager<AR, A>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (AR) -> Int
+): Flow<A> = sagaManager.handleConcurrently(
+    this,
+    numberOfActors,
+    actorsCapacity,
+    actorsStart,
+    actorsContext
+) { partitionKey(it) }
+
+/**
+ * Saga Actor
+ *
+ * @param fanInChannel A reference to the channel this coroutine/actor sends elements/actions to
+ * @param handle A function that handles action-result and sends responses/actions to [fanInChannel]
+ * @receiver CoroutineScope
+ */
+@ObsoleteCoroutinesApi
+private fun <AR, A> CoroutineScope.sagaActor(
+    fanInChannel: SendChannel<A>,
+    capacity: Int = Channel.RENDEZVOUS,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    context: CoroutineContext = EmptyCoroutineContext,
+    handle: suspend (AR, SendChannel<A>) -> Unit
+) = actor<AR>(context, capacity, start) {
+    for (msg in channel) {
+        handle(msg, fanInChannel)
+    }
+}

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Fraktalio D.O.O. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fraktalio.fmodel.application
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.channels.actor
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlin.contracts.ExperimentalContracts
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Extension function - Handles the [Flow] of command messages of type [C] by concurrently distributing the load across finite number of actors/handlers
+ *
+ * @param commands [Flow] of Command messages of type [C]
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return [Flow] of State of type [S]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <C, S, E> StateStoredAggregate<C, S, E>.handleConcurrently(
+    commands: Flow<C>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (C) -> Int
+): Flow<S> = channelFlow {
+    val actors: List<SendChannel<C>> = (1..numberOfActors).map {
+        commandActor(channel, actorsCapacity, actorsStart, actorsContext) { command, channel ->
+            channel.send(handle(command))
+        }
+    }
+    commands
+        .onCompletion {
+            actors.forEach {
+                it.close()
+            }
+        }
+        .collect {
+            val partitionKeyVal = partitionKey(it)
+            val partition = (if (partitionKeyVal < 0) partitionKeyVal * (-1) else partitionKeyVal) % numberOfActors
+            actors[partition].send(it)
+        }
+}
+
+/**
+ * Extension function - Publishes the command of type [C] to the state stored aggregate of type  [StateStoredAggregate]<[C], [S], *> by concurrently distributing the load across finite number of actors/handlers
+ * @receiver [Flow] of commands of type [C]
+ * @param aggregate of type [StateStoredAggregate]<[C], [S], *>
+ * @param numberOfActors total number of actors/workers available for distributing the load
+ * @param actorsCapacity capacity of the actors channel's buffer
+ * @param actorsStart actors coroutine start option
+ * @param actorsContext additional to [CoroutineScope.coroutineContext] context of the actor coroutines.
+ * @return the [Flow] of State of type [S]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+@ExperimentalContracts
+@FlowPreview
+fun <C, S> Flow<C>.publishConcurrentlyTo(
+    aggregate: StateStoredAggregate<C, S, *>,
+    numberOfActors: Int = 100,
+    actorsCapacity: Int = Channel.BUFFERED,
+    actorsStart: CoroutineStart = CoroutineStart.LAZY,
+    actorsContext: CoroutineContext = EmptyCoroutineContext,
+    partitionKey: (C) -> Int
+): Flow<S> =
+    aggregate.handleConcurrently(this, numberOfActors, actorsCapacity, actorsStart, actorsContext) { partitionKey(it) }
+
+
+/**
+ * Command Actor - State Stored Aggregate
+ *
+ * @param fanInChannel A reference to the channel this coroutine/actor sends elements/state to
+ * @param handle A function that handles commands and sends responses/state to [fanInChannel]
+ * @receiver CoroutineScope
+ */
+@ObsoleteCoroutinesApi
+private fun <C, S> CoroutineScope.commandActor(
+    fanInChannel: SendChannel<S>,
+    capacity: Int = Channel.RENDEZVOUS,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    context: CoroutineContext = EmptyCoroutineContext,
+    handle: suspend (C, SendChannel<S>) -> Unit
+) = actor<C>(context, capacity, start) {
+    for (msg in channel) {
+        handle(msg, fanInChannel)
+    }
+}

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
@@ -1,0 +1,109 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.application.examples.numbers.even.command.EvenNumberRepository
+import com.fraktalio.fmodel.application.examples.numbers.even.command.evenNumberRepository
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.examples.numbers.api.Description
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand.AddEvenNumber
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEvent.EvenNumberAdded
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberValue
+import com.fraktalio.fmodel.domain.examples.numbers.even.command.evenNumberDecider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlin.contracts.ExperimentalContracts
+
+/**
+ * DSL - Given
+ */
+@ExperimentalContracts
+@FlowPreview
+private fun <C, S, E> IDecider<C, S, E>.given(
+    repository: EventRepository<C, E>,
+    partitionKey: (C) -> Int,
+    command: () -> Flow<C>
+): Flow<E> =
+    eventSourcingAggregate(
+        decider = this,
+        eventRepository = repository
+    ).handleConcurrently(command()) { partitionKey(it) }
+
+/**
+ * DSL - When
+ */
+@Suppress("unused")
+private fun <C, S, E> IDecider<C, S, E>.whenCommand(command: Flow<C>): Flow<C> = command
+
+/**
+ * DSL - Then
+ */
+private suspend infix fun <E> Flow<E>.thenEventsExactly(expected: Iterable<E>) =
+    toList() shouldContainExactly (expected)
+
+private suspend infix fun <E> Flow<E>.thenEvents(expected: Collection<E>) = toList() shouldContainAll (expected)
+
+/**
+ * Event sourced aggregate actor test
+ */
+@ExperimentalContracts
+@FlowPreview
+class EventSourcedAggregateActorTest : FunSpec({
+    val evenDecider = evenNumberDecider()
+    val evenNumberRepository = evenNumberRepository() as EvenNumberRepository
+
+    test("Event-sourced aggregate actor - add even number") {
+        with(evenDecider) {
+            evenNumberRepository.deleteAll()
+
+            // choosing command `description` hash as a partition key. It is the same for these two commands.
+            given(evenNumberRepository, { it?.description.hashCode() }) {
+                whenCommand(
+                    flowOf(
+                        AddEvenNumber(Description("desc"), NumberValue(6)),
+                        AddEvenNumber(Description("desc"), NumberValue(4))
+                    )
+                )
+            } thenEventsExactly listOf(
+                EvenNumberAdded(Description("desc"), NumberValue(6)),
+                EvenNumberAdded(Description("desc"), NumberValue(4))
+            )
+        }
+    }
+
+    test("Event-sourced aggregate actor - add even number - different partition keys") {
+        with(evenDecider) {
+            evenNumberRepository.deleteAll()
+
+            // choosing command `value` hash as a partition key. It is not the same for these two commands.
+            given(evenNumberRepository, { it?.value.hashCode() }) {
+                whenCommand(
+                    flowOf(
+                        AddEvenNumber(Description("desc"), NumberValue(6)),
+                        AddEvenNumber(Description("desc"), NumberValue(8))
+                    )
+                )
+            } thenEvents listOf(
+                EvenNumberAdded(Description("desc"), NumberValue(8)),
+                EvenNumberAdded(Description("desc"), NumberValue(6))
+            )
+        }
+    }
+
+    test("Event-sourced aggregate actor - add even number - exception (large number > 1000)") {
+        shouldThrow<UnsupportedOperationException> {
+            with(evenDecider) {
+                evenNumberRepository.deleteAll()
+
+                given(evenNumberRepository, { it?.description.hashCode() }) {
+                    whenCommand(flowOf(AddEvenNumber(Description("2000"), NumberValue(2000))))
+                } thenEventsExactly listOf(EvenNumberAdded(Description("2000"), NumberValue(2000)))
+            }
+        }
+    }
+
+})

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
@@ -1,0 +1,111 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.application.examples.numbers.NumberViewRepository
+import com.fraktalio.fmodel.application.examples.numbers.even.query.EvenNumberViewRepository
+import com.fraktalio.fmodel.application.examples.numbers.even.query.evenNumberViewRepository
+import com.fraktalio.fmodel.application.examples.numbers.numberViewRepository
+import com.fraktalio.fmodel.domain.IView
+import com.fraktalio.fmodel.domain.combine
+import com.fraktalio.fmodel.domain.examples.numbers.api.Description
+import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEvent.EvenNumberAdded
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent.OddNumberAdded
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberValue
+import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import com.fraktalio.fmodel.domain.examples.numbers.even.query.evenNumberView
+import com.fraktalio.fmodel.domain.examples.numbers.odd.query.oddNumberView
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlin.contracts.ExperimentalContracts
+
+/**
+ * DSL - Given
+ */
+@FlowPreview
+@ExperimentalContracts
+private fun <S, E> IView<S, E>.given(
+    repository: ViewStateRepository<E, S>,
+    partitionKey: (E) -> Int,
+    event: () -> Flow<E>
+): Flow<S> =
+    materializedView(
+        view = this,
+        viewStateRepository = repository
+    ).handleConcurrently(event()) { partitionKey(it) }
+
+/**
+ * DSL - When
+ */
+@Suppress("unused")
+private fun <S, E> IView<S, E>.whenEvent(events: Flow<E>): Flow<E> = events
+
+/**
+ * DSL - Then
+ */
+private suspend infix fun <S> Flow<S>.thenStateExactly(expected: Iterable<S>) = toList() shouldContainExactly (expected)
+private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toList() shouldContainAll (expected)
+
+/**
+ * Materialized View Actor Test
+ */
+@FlowPreview
+@ExperimentalContracts
+class MaterializedViewActorTest : FunSpec({
+    val evenView = evenNumberView()
+    val oddView = oddNumberView()
+    val combinedView = evenView.combine(oddView)
+    val evenNumberViewRepository = evenNumberViewRepository() as EvenNumberViewRepository
+    val numberViewRepository = numberViewRepository() as NumberViewRepository
+
+    test("Materialized view actor - even number added") {
+        with(evenView) {
+            evenNumberViewRepository.deleteAll()
+
+            given(evenNumberViewRepository, { it?.description.hashCode() }) {
+                whenEvent(
+                    flowOf(
+                        EvenNumberAdded(Description("EvenNumberAdded"), NumberValue(2)),
+                        EvenNumberAdded(Description("EvenNumberAdded"), NumberValue(4))
+                    )
+                )
+            } thenStateExactly listOf(
+                EvenNumberState(Description("Initial state, EvenNumberAdded"), NumberValue(2)),
+                EvenNumberState(Description("Initial state, EvenNumberAdded, EvenNumberAdded"), NumberValue(6)),
+            )
+        }
+    }
+
+    test("Combined Materialized view actor - odd number added") {
+        with(combinedView) {
+            numberViewRepository.deleteAll()
+
+            given(numberViewRepository, { it?.description.hashCode() }) {
+                whenEvent(
+                    flowOf(
+                        OddNumberAdded(Description("3"), NumberValue(3)),
+                        OddNumberAdded(Description("1"), NumberValue(1))
+                    )
+                )
+            } thenState listOf(
+                Pair(null, OddNumberState(Description("0, 3"), NumberValue(3))),
+                Pair(null, OddNumberState(Description("0, 3, 1"), NumberValue(4)))
+            )
+        }
+    }
+
+    test("Combined Materialized view actor- even number added") {
+        with(combinedView) {
+            numberViewRepository.deleteAll()
+
+            given(numberViewRepository, { it?.description.hashCode() }) {
+                whenEvent(flowOf(EvenNumberAdded(Description("4"), NumberValue(4))))
+            } thenStateExactly listOf(Pair(EvenNumberState(Description("0, 4"), NumberValue(4)), null))
+        }
+    }
+
+})

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
@@ -1,0 +1,109 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.application.examples.numbers.NumberStateRepository
+import com.fraktalio.fmodel.application.examples.numbers.even.command.EvenNumberStateRepository
+import com.fraktalio.fmodel.application.examples.numbers.even.command.evenNumberStateRepository
+import com.fraktalio.fmodel.application.examples.numbers.numberStateRepository
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.combine
+import com.fraktalio.fmodel.domain.examples.numbers.api.Description
+import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand.AddEvenNumber
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberValue
+import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import com.fraktalio.fmodel.domain.examples.numbers.even.command.evenNumberDecider
+import com.fraktalio.fmodel.domain.examples.numbers.odd.command.oddNumberDecider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactly
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlin.contracts.ExperimentalContracts
+
+/**
+ * DSL - Given
+ */
+@ExperimentalContracts
+@FlowPreview
+private fun <C, S, E> IDecider<C, S, E>.given(
+    repository: StateRepository<C, S>,
+    partitionKey: (C) -> Int,
+    command: () -> Flow<C>
+): Flow<S> =
+    stateStoredAggregate(
+        decider = this,
+        stateRepository = repository,
+    ).handleConcurrently(command()) { partitionKey(it) }
+
+/**
+ * DSL - When
+ */
+@Suppress("unused")
+private fun <C, S, E> IDecider<C, S, E>.whenCommand(command: Flow<C>): Flow<C> = command
+
+/**
+ * DSL - Then
+ */
+private suspend infix fun <S> Flow<S>.thenStateExactly(expected: Iterable<S>) = toList() shouldContainExactly (expected)
+private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toList() shouldContainAll (expected)
+
+/**
+ * State-stored aggregate actor test
+ */
+@ExperimentalContracts
+@FlowPreview
+class StateStoredAggregateActorTest : FunSpec({
+    val evenDecider = evenNumberDecider()
+    val oddDecider = oddNumberDecider()
+    val combinedDecider = evenDecider.combine(oddDecider)
+    val evenNumberStateRepository = evenNumberStateRepository() as EvenNumberStateRepository
+    val numberStateRepository = numberStateRepository() as NumberStateRepository
+
+    test("State-stored aggregate actor - add even number") {
+        with(evenDecider) {
+            evenNumberStateRepository.deleteAll()
+
+            given(evenNumberStateRepository, { it?.description.hashCode() }) {
+                whenCommand(
+                    flowOf(
+                        AddEvenNumber(Description("desc"), NumberValue(2)),
+                        AddEvenNumber(Description("desc2"), NumberValue(2))
+                    )
+                )
+            } thenState listOf(
+                EvenNumberState(Description("desc"), NumberValue(2)),
+                EvenNumberState(Description("desc2"), NumberValue(4))
+            )
+        }
+    }
+
+    test("State-stored aggregate actor - add even number - exception (large number > 1000)") {
+        shouldThrow<UnsupportedOperationException> {
+            with(evenDecider) {
+                evenNumberStateRepository.deleteAll()
+
+                given(evenNumberStateRepository, { it?.description.hashCode() }) {
+                    whenCommand(flowOf(AddEvenNumber(Description("2000"), NumberValue(2000))))
+                } thenStateExactly listOf(EvenNumberState(Description("2000"), NumberValue(2000)))
+            }
+        }
+    }
+
+    test("Combined State-stored aggregate actor - add even number") {
+        with(combinedDecider) {
+            numberStateRepository.deleteAll()
+
+            given(numberStateRepository, { it?.description.hashCode() }) {
+                whenCommand(flowOf(AddEvenNumber(Description("2"), NumberValue(2))))
+            } thenStateExactly listOf(
+                Pair(
+                    EvenNumberState(Description("2"), NumberValue(2)),
+                    OddNumberState(Description("0"), NumberValue(0))
+                )
+            )
+        }
+    }
+})

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
@@ -1,11 +1,14 @@
 package com.fraktalio.fmodel.domain
 
-import com.fraktalio.fmodel.domain.examples.numbers.api.*
+import com.fraktalio.fmodel.domain.examples.numbers.api.Description
+import com.fraktalio.fmodel.domain.examples.numbers.api.EvenNumberState
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand.AddEvenNumber
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberCommand.AddOddNumber
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.EvenNumberEvent.EvenNumberAdded
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent.OddNumberAdded
+import com.fraktalio.fmodel.domain.examples.numbers.api.NumberValue
+import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 import com.fraktalio.fmodel.domain.examples.numbers.even.command.evenNumberDecider
 import com.fraktalio.fmodel.domain.examples.numbers.odd.command.oddNumberDecider
 import io.kotest.core.spec.style.FunSpec


### PR DESCRIPTION
Experimenting with [Kotlin Actors](https://kotlinlang.org/docs/shared-mutable-state-and-concurrency.html#actors) - concurrently handling messages by confining the shared state effects.

```kotlin
fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
    commands: Flow<C>,
    numberOfActors: Int = 100,
    actorsCapacity: Int = Channel.BUFFERED,
    actorsStart: CoroutineStart = CoroutineStart.LAZY,
    actorsContext: CoroutineContext = EmptyCoroutineContext,
    partitionKey: (C) -> Int
): Flow<E>
```

Extension function - Handles the `Flow` of messages by concurrently distributing the load across a finite number of actors/handlers. `partitionKey` function enables you to choose which messages need to be handled sequentially and which could be handled concurrently. 


Notice, the API is experimental and depends on Kotlin Actor ObsoleteCoroutinesApi. The API is available only on `jvm` target.
