### PR TITLE
WIP - Prototype of Context Receivers /JVM

### DIFF
--- a/application-vanilla/build.gradle.kts
+++ b/application-vanilla/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         compilations.all {
             kotlinOptions.jvmTarget = "1.8"
             kotlinOptions.verbose = true
+            kotlinOptions.freeCompilerArgs = kotlinOptions.freeCompilerArgs + "-Xcontext-receivers"
         }
 
         withJava()

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateContextualExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateContextualExtension.kt
@@ -1,0 +1,123 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.ISaga
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+
+/**
+ * Event-sourced aggregate/decider algorithm
+ * Computes new Events based on the previous Events and the Command.
+ */
+context (IDecider<C, S, E>, C)
+        internal fun <C, S, E> Flow<E>.computeNewEvents(): Flow<E> = flow {
+    val currentState = fold(initialState) { s, e -> evolve(s, e) }
+    val resultingEvents = decide(this@C, currentState)
+    emitAll(resultingEvents)
+}
+
+/**
+ * Event-sourced orchestrating aggregate/decider algorithm
+ * Computes new Events based on the previous Events and the Command.
+ * Saga might react on Events and send new Commands to the Decider.
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, C)
+        @FlowPreview
+        internal fun <C, S, E> Flow<E>.computeNewEvents(): Flow<E> = flow {
+    val currentState = fold(initialState) { s, e -> evolve(s, e) }
+    var resultingEvents = decide(this@C, currentState)
+
+    resultingEvents.flatMapConcat { react(it) }.onEach {
+        val newEvents = flowOf(this@computeNewEvents, resultingEvents).flattenConcat().computeNewEvents()
+        resultingEvents = flowOf(resultingEvents, newEvents).flattenConcat()
+    }.collect()
+
+    emitAll(resultingEvents)
+}
+
+
+/**
+ * Handle command - Event-sourced aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [EventRepository] - context receiver
+ * @receiver command of type C to be handled
+ */
+context (IDecider<C, S, E>, EventRepository<C, E>)
+fun <C, S, E> C.handle(): Flow<E> = fetchEvents().computeNewEvents().save()
+
+/**
+ * Handle command - Event-sourced aggregate/decider
+ * @receiver [EventSourcingAggregate] - context receiver
+ * @receiver command of type C to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, EventRepository<C, E>) C.handle()`, which combines multiple contexts ([IDecider], [EventRepository]) into a single meaningful interface/context [EventSourcingAggregate]
+ */
+context (EventSourcingAggregate<C, S, E>)
+        @FlowPreview
+fun <C, S, E> C.handleIt(): Flow<E> = fetchEvents().computeNewEvents(this).save()
+
+/**
+ * Handle command - Event-sourced orchestrating aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [ISaga] - context receiver
+ * @receiver [EventRepository] - context receiver
+ * @receiver command of type C to be handled
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, EventRepository<C, E>)
+        @FlowPreview
+fun <C, S, E> C.handle(): Flow<E> = fetchEvents().computeNewEvents().save()
+
+/**
+ * Handle command - Event-sourced orchestrating aggregate/decider
+ * @receiver [EventSourcingOrchestratingAggregate] - context receiver
+ * @receiver command of type C to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, ISaga<E, C>, EventRepository<C, E>) C.handle()`, which combines multiple contexts ([IDecider], [ISaga], [EventRepository]) into a single meaningful interface/context [EventSourcingOrchestratingAggregate]
+ */
+context (EventSourcingOrchestratingAggregate<C, S, E>)
+        @FlowPreview
+fun <C, S, E> C.handleIt(): Flow<E> = fetchEvents().computeNewEvents(this).save()
+
+
+/**
+ * Handle command(s) - Event-sourced aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [EventRepository] - context receiver
+ * @receiver commands of type Flow<C> to be handled
+ */
+context (IDecider<C, S, E>, EventRepository<C, E>)
+        @FlowPreview
+fun <C, S, E> Flow<C>.handle(): Flow<E> = flatMapConcat { it.handle() }
+
+/**
+ * Handle command(s) - Event-sourced aggregate/decider
+ * @receiver [EventSourcingAggregate] - context receiver
+ * @receiver commands of type Flow<C> to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, EventRepository<C, E>) Flow<C>.handle()`, which combines multiple contexts ([IDecider], [EventRepository]) into a single meaningful interface/context [EventSourcingAggregate]
+ */
+context (EventSourcingAggregate<C, S, E>)
+        @FlowPreview
+fun <C, S, E> Flow<C>.handleIt(): Flow<E> = flatMapConcat { it.handleIt() }
+
+/**
+ * Handle command(s) - Event-sourced orchestrating aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [ISaga] - context receiver
+ * @receiver [EventRepository] - context receiver
+ * @receiver commands of type Flow<C> to be handled
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, EventRepository<C, E>)
+        @FlowPreview
+fun <C, S, E> Flow<C>.handle(): Flow<E> = flatMapConcat { it.handle() }
+
+/**
+ * Handle command(s) - Event-sourced orchestrating aggregate/decider
+ * @receiver [EventSourcingOrchestratingAggregate] - context receiver
+ * @receiver commands of type Flow<C> to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, ISaga<E, C>, EventRepository<C, E>) Flow<C>.handle()`, which combines multiple contexts ([IDecider], [ISaga], [EventRepository]) into a single meaningful interface/context [EventSourcingOrchestratingAggregate]
+ */
+context (EventSourcingOrchestratingAggregate<C, S, E>)
+        @FlowPreview
+fun <C, S, E> Flow<C>.handleIt(): Flow<E> = flatMapConcat { it.handleIt() }

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewContextualExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewContextualExtension.kt
@@ -1,0 +1,53 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.domain.IView
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+
+/**
+ * Materialized View algorithm
+ * Computes new State based on the previous State and the Event.
+ */
+context (IView<S, E>, E)
+        internal fun <S, E> S?.computeNewState(): S = evolve(this ?: initialState, this@E)
+
+
+/**
+ * Handle event - Materialized View
+ * @receiver [IView] - context receiver
+ * @receiver [ViewStateRepository] - context receiver
+ * @receiver event of type E to be handled
+ */
+context (IView<S, E>, ViewStateRepository<E, S>)
+        suspend fun <S, E> E.handle(): S = fetchState().computeNewState().save()
+
+/**
+ * Handle event - Materialized View
+ * @receiver [MaterializedView] - context receiver
+ * @receiver event of type E to be handled
+ *
+ * Alternative function to `context (IView<S, E>, ViewStateRepository<E, S>) E.handle()`, which combines multiple contexts ([IView], [ViewStateRepository]) into a single meaningful interface/context [MaterializedView]
+ */
+context (MaterializedView<S, E>)
+        suspend fun <S, E> E.handleIt(): S = fetchState().computeNewState(this).save()
+
+
+/**
+ * Handle event(s) - Materialized View
+ * @receiver [IView] - context receiver
+ * @receiver [ViewStateRepository] - context receiver
+ * @receiver events of type Flow<E> to be handled
+ */
+context (IView<S, E>, ViewStateRepository<E, S>)
+fun <S, E> Flow<E>.handle(): Flow<S> = map { it.handle() }
+
+/**
+ * Handle event(s) - Materialized View
+ * @receiver [MaterializedView] - context receiver
+ * @receiver events of type Flow<E> to be handled
+ *
+ * Alternative function to `context (IView<S, E>, ViewStateRepository<E, S>) Flow<E>.handle()`, which combines multiple contexts ([IView], [ViewStateRepository]) into a single meaningful interface/context [MaterializedView]
+ */
+context (MaterializedView<S, E>)
+fun <S, E> Flow<E>.handleIt(): Flow<S> = map { it.handleIt() }

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerContextualExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerContextualExtension.kt
@@ -1,0 +1,54 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.domain.ISaga
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapConcat
+
+
+/**
+ * Materialized View algorithm
+ * Computes new State based on the previous State and the Event.
+ */
+context (ISaga<AR, A>, ActionPublisher<A>)
+        internal fun <AR, A> AR.computeNewActions(): Flow<A> = react(this)
+
+/**
+ * Handle event / action result - Saga Manager
+ * @receiver [ISaga] - context receiver
+ * @receiver [ActionPublisher] - context receiver
+ * @receiver event/action result of type AR to be handled
+ */
+context (ISaga<AR, A>, ActionPublisher<A>)
+fun <AR, A> AR.handle(): Flow<A> = computeNewActions().publish()
+
+/**
+ * Handle event / action result - Saga Manager
+ * @receiver [SagaManager] - context receiver
+ * @receiver event/action result of type AR to be handled
+ *
+ * Alternative function to `context (ISaga<AR, A>, ActionPublisher<A>) AR.handle()`, which combines multiple contexts ([ISaga], [ActionPublisher]) into a single meaningful interface/context [SagaManager]
+ */
+context (SagaManager<AR, A>)
+fun <AR, A> AR.handleIt(): Flow<A> = computeNewActions().publish()
+
+/**
+ * Handle event / action result - Saga Manager
+ * @receiver [ISaga] - context receiver
+ * @receiver [ActionPublisher] - context receiver
+ * @receiver events/actions result of type Flow<AR> to be handled
+ */
+context (ISaga<AR, A>, ActionPublisher<A>)
+        @FlowPreview
+fun <AR, A> Flow<AR>.handle(): Flow<A> = flatMapConcat { it.handle() }
+
+/**
+ * Handle event / action result - Saga Manager
+ * @receiver [SagaManager] - context receiver
+ * @receiver events/actions result of type Flow<AR> to be handled
+ *
+ * Alternative function to `context (ISaga<AR, A>, ActionPublisher<A>) Flow<AR>.handle()`, which combines multiple contexts ([ISaga], [ActionPublisher]) into a single meaningful interface/context [SagaManager]
+ */
+context (SagaManager<AR, A>)
+        @FlowPreview
+fun <AR, A> Flow<AR>.handleIt(): Flow<A> = flatMapConcat { it.handleIt() }

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateContextualExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateContextualExtension.kt
@@ -1,0 +1,118 @@
+package com.fraktalio.fmodel.application
+
+import com.fraktalio.fmodel.domain.IDecider
+import com.fraktalio.fmodel.domain.ISaga
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+
+
+/**
+ * State-stored aggregate/decider algorithm
+ * Computes new State based on the previous State and the Command.
+ */
+context (IDecider<C, S, E>, C)
+        internal suspend fun <C, S, E> S?.computeNewState(): S {
+    val currentState = this ?: initialState
+    val events = decide(this@C, currentState)
+    return events.fold(currentState) { s, e -> evolve(s, e) }
+}
+
+/**
+ * State-stored orchestrating aggregate/decider algorithm
+ * Computes new State based on the previous State and the Command.
+ * Saga might react on Events and send new Commands to the Decider.
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, C)
+        @FlowPreview
+        internal suspend fun <C, S, E> S?.computeNewState(): S {
+    val currentState = this ?: initialState
+    val events = decide(this@C, currentState)
+    val newState = events.fold(currentState) { s, e -> evolve(s, e) }
+    events.flatMapConcat { react(it) }.onEach { newState.computeNewState() }.collect()
+    return newState
+}
+
+/**
+ * Handle command - State-stored aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [StateRepository] - context receiver
+ * @receiver command of type C to be handled
+ */
+context (IDecider<C, S, E>, StateRepository<C, S>)
+        suspend fun <C, S, E> C.handle(): S = fetchState().computeNewState().save()
+
+/**
+ * Handle command - State-stored aggregate/decider
+ * @receiver [StateStoredAggregate] - context receiver
+ * @receiver command of type C to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, StateRepository<C, S>) C.handle()`, which combines multiple contexts ([IDecider], [StateRepository]) into a single meaningful interface/context [StateStoredAggregate]
+ */
+context (StateStoredAggregate<C, S, E>)
+        @FlowPreview
+        suspend fun <C, S, E> C.handleIt(): S = fetchState().computeNewState(this).save()
+
+/**
+ * Handle command - State-stored orchestrating aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [ISaga] - context receiver
+ * @receiver [StateRepository] - context receiver
+ * @receiver command of type C to be handled
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, StateRepository<C, S>)
+        @FlowPreview
+        suspend fun <C, S, E> C.handle(): S = fetchState().computeNewState().save()
+
+/**
+ * Handle command - State-stored orchestrating aggregate/decider
+ * @receiver [StateStoredOrchestratingAggregate] - context receiver
+ * @receiver command of type C to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, ISaga<E, C>, StateRepository<C, S>) C.handle()`, which combines multiple contexts ([IDecider], [ISaga], [StateRepository]) into a single meaningful interface/context [StateStoredOrchestratingAggregate]
+ */
+context (StateStoredOrchestratingAggregate<C, S, E>)
+        @FlowPreview
+        suspend fun <C, S, E> C.handleIt(): S = fetchState().computeNewState(this).save()
+
+
+/**
+ * Handle command(s) - State-stored aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [StateRepository] - context receiver
+ * @receiver commands of type `Flow<C>` to be handled
+ */
+context (IDecider<C, S, E>, StateRepository<C, S>)
+fun <C, S, E> Flow<C>.handle(): Flow<S> = map { it.handle() }
+
+/**
+ * Handle command(s) - State-stored aggregate/decider
+ * @receiver [StateStoredAggregate] - context receiver
+ * @receiver commands of type `Flow<C>` to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, StateRepository<C, S>) Flow<C>.handle()`, which combines multiple contexts ([IDecider], [StateRepository]) into a single meaningful interface/context [StateStoredAggregate]
+ */
+context (StateStoredAggregate<C, S, E>)
+        @FlowPreview
+fun <C, S, E> Flow<C>.handleIt(): Flow<S> = map { it.handleIt() }
+
+/**
+ * Handle command(s) - State-stored orchestrating aggregate/decider
+ * @receiver [IDecider] - context receiver
+ * @receiver [ISaga] - context receiver
+ * @receiver [StateRepository] - context receiver
+ * @receiver commands of type `Flow<C>` to be handled
+ */
+context (IDecider<C, S, E>, ISaga<E, C>, StateRepository<C, S>)
+        @FlowPreview
+        suspend fun <C, S, E> Flow<C>.handle(): Flow<S> = map { it.handle() }
+
+/**
+ * Handle command(s) - State-stored orchestrating aggregate/decider
+ * @receiver [StateStoredOrchestratingAggregate] - context receiver
+ * @receiver commands of type `Flow<C>` to be handled
+ *
+ * Alternative function to `context (IDecider<C, S, E>, ISaga<E, C>, StateRepository<C, S>) Flow<C>.handle()`, which combines multiple contexts ([IDecider], [ISaga], [StateRepository]) into a single meaningful interface/context [StateStoredOrchestratingAggregate]
+ */
+context (StateStoredOrchestratingAggregate<C, S, E>)
+        @FlowPreview
+        suspend fun <C, S, E> Flow<C>.handleIt(): Flow<S> = map { it.handleIt() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 coroutines = "1.6.0"
 dokka = "1.6.10"
 kotest = "5.1.0"
-kotlin = "1.6.10"
+kotlin = "1.6.20-RC"
 arrow = "1.0.1"
 
 [libraries]


### PR DESCRIPTION
Context receivers enable context-dependent declarations in Kotlin.

It enables composing contexts without using inheritance, which can simplify the `application` layer of the systems / orchestrate the logic's execution. `Domain` layer might benefit as well (working with mathematical abstractions - monoid)

Issue: https://github.com/fraktalio/fmodel/issues/71

Kotlin Blog: [https://blog.jetbrains.com/kotlin/2022/02/kotlin-1-6-20-m1-released/#prototype-of-context-receivers-for-kotlin-jvm](https://blog.jetbrains.com/kotlin/2022/02/kotlin-1-6-20-m1-released/#prototype-of-context-receivers-for-kotlin-jvm)