### PR TITLE
Marking the `combine` function as `infix`

### DIFF
--- a/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateArrowExtension.kt
+++ b/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateArrowExtension.kt
@@ -55,7 +55,7 @@ fun <C, S, E> EventSourcingAggregate<C, S, E>.handleWithEffect(command: C): Flow
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handleWithEffect(commands: Flow<C>): Flow<Effect<Error, E>> =
     commands
         .flatMapConcat { handleWithEffect(it) }
-        .catch { emit(effect { shift(CommandPublishingFailed(it)) }) }
+        .catch { emit(effect { shift(CommandHandlingFailed(it)) }) }
 
 /**
  * Extension function - Publishes the command of type [C] to the event sourcing aggregate of type  [EventSourcingAggregate]<[C], *, [E]>

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
@@ -28,6 +28,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberC
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -40,6 +41,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
  * @param repository the event-sourcing repository for all (even and odd) numbers
  * @return the event-sourcing aggregate instance for all (even and odd) numbers
  */
+@OptIn(FlowPreview::class)
 fun numberAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
@@ -28,6 +28,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberC
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -40,6 +41,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
  * @param repository the state-stored repository for all (even and odd) numbers
  * @return the state-stored aggregate instance for all (even and odd) numbers
  */
+@OptIn(FlowPreview::class)
 fun numberStateStoredAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/domain/examples/numbers/NumberSaga.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/domain/examples/numbers/NumberSaga.kt
@@ -80,7 +80,7 @@ fun numberSaga() = Saga<NumberEvent, NumberCommand>(
  * @return even number Saga instance
  */
 fun evenNumberSaga() = Saga<NumberEvent.EvenNumberEvent?, NumberCommand.OddNumberCommand>(
-    react = { numberEvent -> emptyFlow() }
+    react = { emptyFlow() }
 )
 
 /**

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
@@ -28,6 +28,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberC
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -40,6 +41,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
  * @param repository the event-sourcing repository for all (even and odd) numbers
  * @return the event-sourcing aggregate instance for all (even and odd) numbers
  */
+@OptIn(FlowPreview::class)
 fun numberAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
@@ -28,6 +28,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.OddNumberC
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
+import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -40,6 +41,7 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
  * @param repository the state-stored repository for all (even and odd) numbers
  * @return the state-stored aggregate instance for all (even and odd) numbers
  */
+@OptIn(FlowPreview::class)
 fun numberStateStoredAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/domain/examples/numbers/NumberSaga.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/domain/examples/numbers/NumberSaga.kt
@@ -68,7 +68,7 @@ fun numberSaga() = Saga<NumberEvent?, NumberCommand?>(
  * @return even number Saga instance
  */
 fun evenNumberSaga() = Saga<NumberEvent.EvenNumberEvent?, NumberCommand.OddNumberCommand>(
-    react = { numberEvent -> emptyFlow() }
+    react = { emptyFlow() }
 )
 
 /**

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
@@ -28,6 +28,7 @@ import kotlin.math.absoluteValue
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
@@ -68,6 +69,7 @@ fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <C, E> Flow<C>.publishConcurrentlyTo(

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
@@ -45,6 +45,7 @@ import kotlin.math.absoluteValue
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <S, E> MaterializedView<S, E>.handleConcurrently(
@@ -84,6 +85,7 @@ fun <S, E> MaterializedView<S, E>.handleConcurrently(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @FlowPreview
 @ExperimentalContracts
 fun <S, E> Flow<E>.publishConcurrentlyTo(

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
@@ -44,6 +44,7 @@ import kotlin.math.absoluteValue
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <AR, A> SagaManager<AR, A>.handleConcurrently(
@@ -82,6 +83,7 @@ fun <AR, A> SagaManager<AR, A>.handleConcurrently(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <AR, A> Flow<AR>.publishConcurrentlyTo(

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
@@ -44,6 +44,7 @@ import kotlin.math.absoluteValue
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <C, S, E> StateStoredAggregate<C, S, E>.handleConcurrently(
@@ -82,6 +83,7 @@ fun <C, S, E> StateStoredAggregate<C, S, E>.handleConcurrently(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 fun <C, S> Flow<C>.publishConcurrentlyTo(

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
@@ -13,6 +13,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -21,6 +22,7 @@ import kotlin.contracts.ExperimentalContracts
 /**
  * DSL - Given
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
@@ -50,6 +52,7 @@ private suspend infix fun <E> Flow<E>.thenEvents(expected: Collection<E>) = toLi
 /**
  * Event sourced aggregate actor test
  */
+@OptIn(ObsoleteCoroutinesApi::class)
 @ExperimentalContracts
 @FlowPreview
 class EventSourcedAggregateActorTest : FunSpec({

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
@@ -18,6 +18,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -26,6 +27,7 @@ import kotlin.contracts.ExperimentalContracts
 /**
  * DSL - Given
  */
+@ObsoleteCoroutinesApi
 @FlowPreview
 @ExperimentalContracts
 private fun <S, E> IView<S, E>.given(
@@ -53,6 +55,7 @@ private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toLis
 /**
  * Materialized View Actor Test
  */
+@OptIn(ObsoleteCoroutinesApi::class)
 @FlowPreview
 @ExperimentalContracts
 class MaterializedViewActorTest : FunSpec({

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
@@ -18,6 +18,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -26,6 +27,7 @@ import kotlin.contracts.ExperimentalContracts
 /**
  * DSL - Given
  */
+@ObsoleteCoroutinesApi
 @ExperimentalContracts
 @FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
@@ -53,6 +55,7 @@ private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toLis
 /**
  * State-stored aggregate actor test
  */
+@OptIn(ObsoleteCoroutinesApi::class)
 @ExperimentalContracts
 @FlowPreview
 class StateStoredAggregateActorTest : FunSpec({

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
@@ -223,7 +223,7 @@ fun <C, Si, So, Ei, Eo, Son> _Decider<C, Si, So, Ei, Eo>.productOnState(
  * @return [_Decider]<[C_SUPER], [Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [Ei_SUPER], [Eo_SUPER]>
  */
 @FlowPreview
-inline fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, reified C2 : C_SUPER, Si2, So2, reified Ei2 : Ei_SUPER, Eo2 : Eo_SUPER, C_SUPER, Ei_SUPER, Eo_SUPER> _Decider<C?, Si, So, Ei?, Eo>.combine(
+inline infix fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, reified C2 : C_SUPER, Si2, So2, reified Ei2 : Ei_SUPER, Eo2 : Eo_SUPER, C_SUPER, Ei_SUPER, Eo_SUPER> _Decider<C?, Si, So, Ei?, Eo>.combine(
     y: _Decider<C2?, Si2, So2, Ei2?, Eo2>
 ): _Decider<C_SUPER, Pair<Si, Si2>, Pair<So, So2>, Ei_SUPER, Eo_SUPER> {
 
@@ -235,5 +235,3 @@ inline fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, r
 
     return deciderX.productOnState(deciderY)
 }
-
-

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Saga.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Saga.kt
@@ -100,7 +100,7 @@ data class _Saga<in AR, out A>(
  * @return new Saga of type `[_Saga]<[AR_SUPER], [A_SUPER]>`
  */
 @FlowPreview
-inline fun <reified AR : AR_SUPER, A : A_SUPER, reified AR2 : AR_SUPER, A2 : A_SUPER, AR_SUPER, A_SUPER> _Saga<AR?, A>.combine(
+inline infix fun <reified AR : AR_SUPER, A : A_SUPER, reified AR2 : AR_SUPER, A2 : A_SUPER, AR_SUPER, A_SUPER> _Saga<AR?, A>.combine(
     y: _Saga<AR2?, A2>
 ): _Saga<AR_SUPER, A_SUPER> {
 

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/View.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/View.kt
@@ -156,7 +156,7 @@ fun <Si, So, E, Son> _View<Si, So, E>.productOnState(fb: _View<Si, Son, E>): _Vi
  * @param y second View
  * @return new View of type [_View]<[Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [E_SUPER]>
  */
-inline fun <Si, So, reified E : E_SUPER, Si2, So2, reified E2 : E_SUPER, E_SUPER> _View<Si, So, E?>.combine(
+inline infix fun <Si, So, reified E : E_SUPER, Si2, So2, reified E2 : E_SUPER, E_SUPER> _View<Si, So, E?>.combine(
     y: _View<Si2, So2, E2?>
 ): _View<Pair<Si, Si2>, Pair<So, So2>, E_SUPER> {
 

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
@@ -111,7 +111,7 @@ class DeciderTest : FunSpec({
     }
 
     test("Event-sourced Combined Decider - add even number") {
-        val combinedDecider = evenDecider.combine(oddDecider)
+        val combinedDecider = evenDecider combine oddDecider
         with(combinedDecider) {
             givenEvents(emptyList()) {
                 whenCommand(AddEvenNumber(Description("2"), NumberValue(2)))
@@ -120,7 +120,7 @@ class DeciderTest : FunSpec({
     }
 
     test("State-stored Combined Decider - add even number") {
-        val combinedDecider = evenDecider.combine(oddDecider)
+        val combinedDecider = evenDecider combine oddDecider
         with(combinedDecider) {
             givenState(null) {
                 whenCommand(AddEvenNumber(Description("2"), NumberValue(2)))
@@ -132,7 +132,7 @@ class DeciderTest : FunSpec({
     }
 
     test("Event-sourced Combined Decider - given previous state, add even number") {
-        val combinedDecider = evenDecider.combine(oddDecider)
+        val combinedDecider = evenDecider combine oddDecider
         with(combinedDecider) {
             givenEvents(listOf(EvenNumberAdded(Description("2"), NumberValue(2)))) {
                 whenCommand(AddEvenNumber(Description("4"), NumberValue(4)))
@@ -141,7 +141,7 @@ class DeciderTest : FunSpec({
     }
 
     test("State-stored Combined Decider - given previous state, add even number") {
-        val combinedDecider = evenDecider.combine(oddDecider)
+        val combinedDecider = evenDecider combine oddDecider
         with(combinedDecider) {
             givenState(
                 Pair(

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/SagaTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/SagaTest.kt
@@ -37,7 +37,7 @@ class SagaTest : FunSpec({
     }
 
     test("Combined Saga - even number added") {
-        val combinedSaga = evenSaga.combine(oddSaga)
+        val combinedSaga = evenSaga combine oddSaga
         with(combinedSaga) {
             whenActionResult(
                 EvenNumberAdded(Description("2"), NumberValue(2))
@@ -51,7 +51,7 @@ class SagaTest : FunSpec({
     }
 
     test("Combined Saga - odd number added") {
-        val combinedSaga = evenSaga.combine(oddSaga)
+        val combinedSaga = evenSaga combine oddSaga
         with(combinedSaga) {
             whenActionResult(
                 OddNumberAdded(Description("1"), NumberValue(1))

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/ViewTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/ViewTest.kt
@@ -76,7 +76,7 @@ class ViewTest : FunSpec({
     }
 
     test("Mapped View (combine Views) - even and odd numbers added") {
-        val combinedView = evenView.combine(oddView)
+        val combinedView = evenView combine oddView
         with(combinedView) {
             givenEvents(
                 listOf(


### PR DESCRIPTION
Marking the `combine` function as `infix`

infix notation = omitting the dot and the parentheses for the call.
[https://kotlinlang.org/docs/functions.html#infix-notation](https://kotlinlang.org/docs/functions.html#infix-notation)