### PR TITLE
Minimizing the public API of the Domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,31 +138,23 @@ data class Decider<C, S, E>(
 
 ## Decider
 
-`_Decider` is a datatype that represents the main decision-making algorithm. It belongs to the Domain layer. It has five
-generic parameters `C`, `Si`, `So`, `Ei`, `Eo` , representing the type of the values that `_Decider` may contain or use.
-`_Decider` can be specialized for any type `C` or `Si` or `So` or `Ei` or `Eo` because these types do not affect its
-behavior. `_Decider` behaves the same for `C`=`Int` or `C`=`YourCustomType`, for example.
+`Decider` is a datatype that represents the main decision-making algorithm. It belongs to the Domain layer. It has three
+generic parameters `C`, `S`, `E` , representing the type of the values that `Decider` may contain or use.
+`Decider` can be specialized for any type `C` or `S` or `E` because these types do not affect its
+behavior. `Decider` behaves the same for `C`=`Int` or `C`=`YourCustomType`, for example.
 
-`_Decider` is a pure domain component.
+`Decider` is a pure domain component.
 
 - `C` - Command
-- `Si` - input State
-- `So` - output State
-- `Ei` - input Event
-- `Eo` - output Event
-
-We make a difference between input and output types, and we are more general in this case. We can always specialize down
-to the 3 generic parameters: `typealias Decider<C, S, E> = _Decider<C, S, S, E, E>`
+- `S` - State
+- `E` - Event
 
 ```kotlin
-data class _Decider<C, Si, So, Ei, Eo>(
-    val decide: (C, Si) -> Flow<Eo>,
-    val evolve: (Si, Ei) -> So,
-    val initialState: So
-) : I_Decider<C, Si, So, Ei, Eo>
-
-typealias Decider<C, S, E> = _Decider<C, S, S, E, E>
-typealias IDecider<C, S, E> = I_Decider<C, S, S, E, E>
+data class Decider<in C, S, E>(
+    override val decide: (C, S) -> Flow<E>,
+    override val evolve: (S, E) -> S,
+    override val initialState: S
+) : IDecider<C, S, E> 
 ```
 
 Additionally, `initialState` of the Decider is introduced to gain more control over the initial state of the Decider.
@@ -216,7 +208,7 @@ fun restaurantOrderDecider() = Decider<RestaurantOrderCommand?, RestaurantOrder?
 
 #### Contravariant
 
-- `Decider<C, S, E>.mapLeftOnCommand(f: (Cn) -> C): Decider<Cn, S, E`
+- `Decider<C, S, E>.mapLeftOnCommand(f: (Cn) -> C): Decider<Cn, S, E>`
 
 #### Profunctor (Contravariant and Covariant)
 
@@ -341,31 +333,24 @@ scenarios that are offered out of the box.
 
 ## View
 
-`_View`  is a datatype that represents the event handling algorithm, responsible for translating the events into
+`View`  is a datatype that represents the event handling algorithm, responsible for translating the events into
 denormalized state, which is more adequate for querying. It belongs to the Domain layer. It is usually used to create
 the view/query side of the CQRS pattern. Obviously, the command side of the CQRS is usually event-sourced aggregate.
 
-It has three generic parameters `Si`, `So`, `E`, representing the type of the values that `_View` may contain or use.
-`_View` can be specialized for any type of `Si`, `So`, `E` because these types do not affect its behavior.
-`_View` behaves the same for `E`=`Int` or `E`=`YourCustomType`, for example.
+It has two generic parameters `S`, `E`, representing the type of the values that `View` may contain or use.
+`View` can be specialized for any type of `S`, `E` because these types do not affect its behavior.
+`View` behaves the same for `E`=`Int` or `E`=`YourCustomType`, for example.
 
-`_View` is a pure domain component.
+`View` is a pure domain component.
 
-- `Si` - input State
-- `So` - output State
-- `E`  - Event
-
-We make a difference between input and output types, and we are more general in this case. We can always specialize down
-to the 2 generic parameters: `typealias View<S, E> = _View<S, S, E>`
+- `S` - State
+- `E` - Event
 
 ```kotlin
-data class _View<Si, So, E>(
-    val evolve: (Si, E) -> So,
-    val initialState: So,
-) : I_View<Si, So, E>
-
-typealias View<S, E> = _View<S, S, E>
-typealias IView<S, E> = I_View<S, S, E>
+data class View<S, in E>(
+    override val evolve: (S, E) -> S,
+    override val initialState: S
+) : IView<S, E>
 ```
 
 Notice that `View` implements an interface `IView` to communicate the contract.
@@ -409,7 +394,7 @@ fun restaurantOrderView() = View<RestaurantOrderViewState?, RestaurantOrderEvent
 
 - `View<S, E>.dimapOnState(fl: (Sn) -> S, fr: (S) -> Sn): View<Sn, E>`
 
-#### Monoid
+#### *Commutative* Monoid
 
 - `<Sx, reified Ex : E_SUPER, Sy, reified Ey : E_SUPER, E_SUPER>  View<Sx, Ex?>.combine(y: View<Sy, Ey?>): View<Pair<Sx, Sy>, E_SUPER>`
 - with identity element `View<Unit, Nothing?>`

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
@@ -17,41 +17,24 @@
 package com.fraktalio.fmodel.domain
 
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
 
 /**
- * An Interface of the [_Decider].
- *
- * @param C Command type - contravariant/in type parameter
- * @param Si Input State type - contravariant/in type parameter
- * @param So Output State type - covariant/out type parameter
- * @param Ei Input Event type - contravariant/in type parameter
- * @param Eo Output Event type - covariant/out type parameter
- *
- * @see [IDecider]
- *
- * @author Иван Дугалић / Ivan Dugalic / @idugalic
- */
-interface I_Decider<in C, in Si, out So, in Ei, out Eo> {
-    val decide: (C, Si) -> Flow<Eo>
-    val evolve: (Si, Ei) -> So
-    val initialState: So
-}
-
-/**
- * A convenient typealias for the [I_Decider] interface. It is specializing the five parameters [I_Decider] interface to only three parameters interface [IDecider].
- *
  * @param C Command
  * @param S State
  * @param E Event
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-typealias IDecider<C, S, E> = I_Decider<C, S, S, E, E>
+interface IDecider<in C, S, E> {
+    val decide: (C, S) -> Flow<E>
+    val evolve: (S, E) -> S
+    val initialState: S
+}
 
 /**
- * A typealias for [_Decider]<C, Si, So, Ei, Eo>, specializing the [_Decider] to three generic parameters: C/Command, S/State and E/Event
- *
  * [Decider] is a datatype that represents the main decision-making algorithm.
  * It has three generic parameters `C`, `S`, `E` , representing the type of the values that [Decider] may contain or use.
  * [Decider] can be specialized for any type `C` or `S` or `E` because these types does not affect its behavior.
@@ -86,7 +69,82 @@ typealias IDecider<C, S, E> = I_Decider<C, S, S, E, E>
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-typealias Decider<C, S, E> = _Decider<C, S, S, E, E>
+data class Decider<in C, S, E>(
+    override val decide: (C, S) -> Flow<E>,
+    override val evolve: (S, E) -> S,
+    override val initialState: S
+) : IDecider<C, S, E> {
+
+    @PublishedApi
+    internal constructor(decider: InternalDecider<C, S, S, E, E>) : this(
+        decider.decide,
+        decider.evolve,
+        decider.initialState
+    )
+
+    /**
+     * Left map on C/Command parameter
+     *
+     * @param Cn Command new
+     * @param f Function that maps type `Cn` to `C`
+     *
+     * @return New Decider of type [Decider]<[Cn], [S], [E]>
+     */
+    inline fun <Cn> mapLeftOnCommand(
+        crossinline f: (Cn) -> C
+    ): Decider<Cn, S, E> = Decider(InternalDecider(decide, evolve, initialState).mapLeftOnCommand(f))
+
+    /**
+     * Di-map on E/Event parameter
+     *
+     * @param En Event new
+     * @param fl Function that maps type `En` to `E`
+     * @param fr Function that maps type `E` to `En`
+     *
+     * @return New Decider of type [Decider]<[C], [S], [En]>
+     */
+    inline fun <En> dimapOnEvent(
+        crossinline fl: (En) -> E, crossinline fr: (E) -> En
+    ): Decider<C, S, En> = Decider(InternalDecider(decide, evolve, initialState).dimapOnEvent(fl, fr))
+
+    /**
+     * Di-map on S/State parameter
+     *
+     * @param Sn State new
+     * @param fl Function that maps type `Sn` to `S`
+     * @param fr Function that maps type `S` to `Sn`
+     */
+    inline fun <Sn> dimapOnState(
+        crossinline fl: (Sn) -> S, crossinline fr: (S) -> Sn
+    ): Decider<C, Sn, E> = Decider(InternalDecider(decide, evolve, initialState).dimapOnState(fl, fr))
+
+}
+
+/**
+ * Combine [Decider]s into one [Decider]
+ *
+ * Possible to use when:
+ *
+ * - [E] and [E2] have common superclass [E_SUPER]
+ * - [C] and [C2] have common superclass [C_SUPER]
+ *
+ * @param C Command type of the first Decider
+ * @param S State type of the first Decider
+ * @param E Event type of the first Decider
+ * @param C2 Command type of the second Decider
+ * @param S2 Input_State type of the second Decider
+ * @param E2 Event type of the second Decider
+ * @param C_SUPER super type of the command types C and C2
+ * @param E_SUPER super type of the E and E2 types
+ * @param y second Decider
+ * @return [Decider]<[C_SUPER], [Pair]<[S], [S2]>, [E_SUPER]>
+ */
+@FlowPreview
+inline infix fun <reified C : C_SUPER, S, reified E : E_SUPER, reified C2 : C_SUPER, S2, reified E2 : E_SUPER, C_SUPER, E_SUPER> Decider<C?, S, E?>.combine(
+    y: Decider<C2?, S2, E2?>
+): Decider<C_SUPER?, Pair<S, S2>, E_SUPER?> = Decider(
+    InternalDecider(decide, evolve, initialState).combine(InternalDecider(y.decide, y.evolve, y.initialState))
+)
 
 /**
  * Decider DSL - A convenient builder DSL for the [Decider]
@@ -143,196 +201,3 @@ class DeciderBuilder<C, S, E> internal constructor() {
     fun build(): Decider<C, S, E> = Decider(decide, evolve, initialState())
 }
 
-/**
- * [_Decider] is a datatype that represents the main decision-making algorithm.
- * It has five generic parameters [C], [Si], [So], [Ei], [Eo] , representing the type of the values that [_Decider] may contain or use.
- * [_Decider] can be specialized for any type [C] or [Si] or [So] or [Ei] or [Eo] because these types does not affect its behavior.
- * [_Decider] behaves the same for [C]=[Int] or [C]=YourCustomType, for example.
- *
- * [_Decider] is a pure domain component.
- *
- * @param C Command type - contravariant/in type parameter
- * @param Si Input State type - contravariant/in type parameter
- * @param So Output State type - covariant/out type parameter
- * @param Ei Input Event type - contravariant/in type parameter
- * @param Eo Output Event type - covariant/out type parameter
- * @property decide A function/lambda that takes command of type [C] and input state of type [Si] as parameters, and returns/emits the flow of output events [Flow]<[Eo]>
- * @property evolve A function/lambda that takes input state of type [Si] and input event of type [Ei] as parameters, and returns the output/new state [So]
- * @property initialState A starting point / An initial state of type [So]
- * @constructor Creates [_Decider]
- *
- * @see [Decider]
- *
- * @author Иван Дугалић / Ivan Dugalic / @idugalic
- */
-data class _Decider<in C, in Si, out So, in Ei, out Eo>(
-    override val decide: (C, Si) -> Flow<Eo>,
-    override val evolve: (Si, Ei) -> So,
-    override val initialState: So
-) : I_Decider<C, Si, So, Ei, Eo> {
-    /**
-     * Left map on C/Command parameter - Contravariant
-     *
-     * @param Cn Command new
-     * @param f
-     */
-    inline fun <Cn> mapLeftOnCommand(
-        crossinline f: (Cn) -> C
-    ): _Decider<Cn, Si, So, Ei, Eo> = _Decider(
-        decide = { cn, si -> decide(f(cn), si) },
-        evolve = { si, ei -> evolve(si, ei) },
-        initialState = initialState
-    )
-
-    /**
-     * Dimap on E/Event parameter - Contravariant on input event and Covariant on output event = Profunctor
-     *
-     * @param Ein Event input new
-     * @param Eon Event output new
-     * @param fl
-     * @param fr
-     */
-    inline fun <Ein, Eon> dimapOnEvent(
-        crossinline fl: (Ein) -> Ei, crossinline fr: (Eo) -> Eon
-    ): _Decider<C, Si, So, Ein, Eon> = _Decider(
-        decide = { c, si -> decide(c, si).map { fr(it) } },
-        evolve = { si, ein -> evolve(si, fl(ein)) },
-        initialState = initialState
-    )
-
-    /**
-     * Left map on E/Event parameter - Contravariant
-     *
-     * @param Ein Event input new
-     * @param f
-     */
-    internal inline fun <Ein> mapLeftOnEvent(crossinline f: (Ein) -> Ei): _Decider<C, Si, So, Ein, Eo> =
-        dimapOnEvent(f) { it }
-
-    /**
-     * Right map on E/Event parameter - Covariant
-     *
-     * @param Eon Event output new
-     * @param f
-     */
-    internal inline fun <Eon> mapOnEvent(crossinline f: (Eo) -> Eon): _Decider<C, Si, So, Ei, Eon> =
-        dimapOnEvent({ it }, f)
-
-    /**
-     * Dimap on S/State parameter - Contravariant on input state (Si) and Covariant on output state (So) = Profunctor
-     *
-     * @param Sin State input new
-     * @param Son State output new
-     * @param fl
-     * @param fr
-     */
-    inline fun <Sin, Son> dimapOnState(
-        crossinline fl: (Sin) -> Si, crossinline fr: (So) -> Son
-    ): _Decider<C, Sin, Son, Ei, Eo> = _Decider(
-        decide = { c, sin -> decide(c, fl(sin)) },
-        evolve = { sin, ei -> fr(evolve(fl(sin), ei)) },
-        initialState = fr(initialState)
-    )
-
-    /**
-     * Left map on S/State parameter - Contravariant
-     *
-     * @param Sin State input new
-     * @param f
-     */
-    @PublishedApi
-    internal inline fun <Sin> mapLeftOnState(crossinline f: (Sin) -> Si): _Decider<C, Sin, So, Ei, Eo> =
-        dimapOnState(f) { it }
-
-    /**
-     * Right map on S/State parameter - Covariant
-     *
-     * @param Son State output new
-     * @param f
-     */
-    @PublishedApi
-    internal inline fun <Son> mapOnState(crossinline f: (So) -> Son): _Decider<C, Si, Son, Ei, Eo> =
-        dimapOnState({ it }, f)
-}
-
-/**
- * Apply on S/State - Applicative
- *
- * @param C Command type
- * @param Si Input_State type
- * @param So Output_State type
- * @param Ei Input_Event type
- * @param Eo Output_Event type
- * @param Son Output_State type new
- *
- * @param ff of type [_Decider]<[C], [Si], ([So]) -> [Son], [Ei], [Eo]>
- *
- * @return new decider of type [_Decider]<[C], [Si], [Son], [Ei], [Eo]>
- */
-@FlowPreview
-internal fun <C, Si, So, Ei, Eo, Son> _Decider<C, Si, So, Ei, Eo>.applyOnState(
-    ff: _Decider<C, Si, (So) -> Son, Ei, Eo>
-): _Decider<C, Si, Son, Ei, Eo> = _Decider(
-    decide = { c, si -> flowOf(ff.decide(c, si), decide(c, si)).flattenConcat() },
-    evolve = { si, ei -> ff.evolve(si, ei)(evolve(si, ei)) },
-    initialState = ff.initialState(initialState)
-)
-
-/**
- * Product on S/State parameter - Applicative
- *
- * @param C Command type
- * @param Si Input_State type
- * @param So Output_State type
- * @param Ei Input_Event type
- * @param Eo Output_Event type
- * @param Son Output_State type new
- * @param fb
- *
- * @return new decider of type [_Decider]<[C], [Si], [Pair]<[So], [Son]>, [Ei], [Eo]>
- */
-@FlowPreview
-@PublishedApi
-internal fun <C, Si, So, Ei, Eo, Son> _Decider<C, Si, So, Ei, Eo>.productOnState(
-    fb: _Decider<C, Si, Son, Ei, Eo>
-): _Decider<C, Si, Pair<So, Son>, Ei, Eo> = applyOnState(fb.mapOnState { b: Son -> { a: So -> Pair(a, b) } })
-
-
-/**
- * Combine [_Decider]s into one big [_Decider]
- *
- * Possible to use when:
- *
- * - [Ei] and [Ei2] have common superclass [Ei_SUPER]
- * - [Eo] and [Eo2] have common superclass [Eo_SUPER]
- * - [C] and [C2] have common superclass [C_SUPER]
- *
- * @param C Command type of the first Decider
- * @param Si Input_State type of the first Decider
- * @param So Output_State type of the first Decider
- * @param Ei Input_Event type of the first Decider
- * @param Eo Output_Event type of the first Decider
- * @param C2 Command type of the second Decider
- * @param Si2 Input_State type of the second Decider
- * @param So2 Output_State type of the second Decider
- * @param Ei2 Input_Event type of the second Decider
- * @param Eo2 Output_Event type of the second Decider
- * @param C_SUPER super type of the command types C and C2
- * @param Ei_SUPER super type of the Ei and Ei2 types
- * @param Eo_SUPER super type of the Eo and Eo2 types
- * @param y second Decider
- * @return [_Decider]<[C_SUPER], [Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [Ei_SUPER], [Eo_SUPER]>
- */
-@FlowPreview
-inline infix fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, reified C2 : C_SUPER, Si2, So2, reified Ei2 : Ei_SUPER, Eo2 : Eo_SUPER, C_SUPER, Ei_SUPER, Eo_SUPER> _Decider<C?, Si, So, Ei?, Eo>.combine(
-    y: _Decider<C2?, Si2, So2, Ei2?, Eo2>
-): _Decider<C_SUPER, Pair<Si, Si2>, Pair<So, So2>, Ei_SUPER, Eo_SUPER> {
-
-    val deciderX = this.mapLeftOnCommand<C_SUPER> { it as? C }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.first }
-        .dimapOnEvent<Ei_SUPER, Eo_SUPER>({ it as? Ei }, { it })
-
-    val deciderY = y.mapLeftOnCommand<C_SUPER> { it as? C2 }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.second }
-        .dimapOnEvent<Ei_SUPER, Eo_SUPER>({ it as? Ei2 }, { it })
-
-    return deciderX.productOnState(deciderY)
-}

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/InternalDecider.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/InternalDecider.kt
@@ -1,0 +1,204 @@
+package com.fraktalio.fmodel.domain
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flattenConcat
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+/**
+ * [InternalDecider] is a datatype that represents the main decision-making algorithm.
+ * It has five generic parameters [C], [Si], [So], [Ei], [Eo] , representing the type of the values that [InternalDecider] may contain or use.
+ * [InternalDecider] can be specialized for any type [C] or [Si] or [So] or [Ei] or [Eo] because these types does not affect its behavior.
+ * [InternalDecider] behaves the same for [C]=[Int] or [C]=YourCustomType, for example.
+ *
+ * [InternalDecider] is a pure domain component.
+ *
+ * @param C Command type - contravariant/in type parameter
+ * @param Si Input State type - contravariant/in type parameter
+ * @param So Output State type - covariant/out type parameter
+ * @param Ei Input Event type - contravariant/in type parameter
+ * @param Eo Output Event type - covariant/out type parameter
+ * @property decide A function/lambda that takes command of type [C] and input state of type [Si] as parameters, and returns/emits the flow of output events [Flow]<[Eo]>
+ * @property evolve A function/lambda that takes input state of type [Si] and input event of type [Ei] as parameters, and returns the output/new state [So]
+ * @property initialState A starting point / An initial state of type [So]
+ * @constructor Creates [InternalDecider]
+ *
+ * @see [Decider]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+
+@PublishedApi
+internal data class InternalDecider<in C, in Si, out So, in Ei, out Eo>(
+    val decide: (C, Si) -> Flow<Eo>,
+    val evolve: (Si, Ei) -> So,
+    val initialState: So
+) {
+    /**
+     * Left map on C/Command parameter - Contravariant
+     *
+     * @param Cn Command new
+     * @param f
+     */
+    inline fun <Cn> mapLeftOnCommand(
+        crossinline f: (Cn) -> C
+    ): InternalDecider<Cn, Si, So, Ei, Eo> = InternalDecider(
+        decide = { cn, si -> decide(f(cn), si) },
+        evolve = { si, ei -> evolve(si, ei) },
+        initialState = initialState
+    )
+
+    /**
+     * Dimap on E/Event parameter - Contravariant on input event and Covariant on output event = Profunctor
+     *
+     * @param Ein Event input new
+     * @param Eon Event output new
+     * @param fl
+     * @param fr
+     */
+    inline fun <Ein, Eon> dimapOnEvent(
+        crossinline fl: (Ein) -> Ei, crossinline fr: (Eo) -> Eon
+    ): InternalDecider<C, Si, So, Ein, Eon> = InternalDecider(
+        decide = { c, si -> decide(c, si).map { fr(it) } },
+        evolve = { si, ein -> evolve(si, fl(ein)) },
+        initialState = initialState
+    )
+
+    /**
+     * Left map on E/Event parameter - Contravariant
+     *
+     * @param Ein Event input new
+     * @param f
+     */
+    inline fun <Ein> mapLeftOnEvent(crossinline f: (Ein) -> Ei): InternalDecider<C, Si, So, Ein, Eo> =
+        dimapOnEvent(f) { it }
+
+    /**
+     * Right map on E/Event parameter - Covariant
+     *
+     * @param Eon Event output new
+     * @param f
+     */
+    inline fun <Eon> mapOnEvent(crossinline f: (Eo) -> Eon): InternalDecider<C, Si, So, Ei, Eon> =
+        dimapOnEvent({ it }, f)
+
+    /**
+     * Dimap on S/State parameter - Contravariant on input state (Si) and Covariant on output state (So) = Profunctor
+     *
+     * @param Sin State input new
+     * @param Son State output new
+     * @param fl
+     * @param fr
+     */
+    inline fun <Sin, Son> dimapOnState(
+        crossinline fl: (Sin) -> Si, crossinline fr: (So) -> Son
+    ): InternalDecider<C, Sin, Son, Ei, Eo> = InternalDecider(
+        decide = { c, sin -> decide(c, fl(sin)) },
+        evolve = { sin, ei -> fr(evolve(fl(sin), ei)) },
+        initialState = fr(initialState)
+    )
+
+    /**
+     * Left map on S/State parameter - Contravariant
+     *
+     * @param Sin State input new
+     * @param f
+     */
+    inline fun <Sin> mapLeftOnState(crossinline f: (Sin) -> Si): InternalDecider<C, Sin, So, Ei, Eo> =
+        dimapOnState(f) { it }
+
+    /**
+     * Right map on S/State parameter - Covariant
+     *
+     * @param Son State output new
+     * @param f
+     */
+    inline fun <Son> mapOnState(crossinline f: (So) -> Son): InternalDecider<C, Si, Son, Ei, Eo> =
+        dimapOnState({ it }, f)
+}
+
+/**
+ * Apply on S/State - Applicative
+ *
+ * @param C Command type
+ * @param Si Input_State type
+ * @param So Output_State type
+ * @param Ei Input_Event type
+ * @param Eo Output_Event type
+ * @param Son Output_State type new
+ *
+ * @param ff of type [InternalDecider]<[C], [Si], ([So]) -> [Son], [Ei], [Eo]>
+ *
+ * @return new decider of type [InternalDecider]<[C], [Si], [Son], [Ei], [Eo]>
+ */
+@FlowPreview
+internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.applyOnState(
+    ff: InternalDecider<C, Si, (So) -> Son, Ei, Eo>
+): InternalDecider<C, Si, Son, Ei, Eo> = InternalDecider(
+    decide = { c, si -> flowOf(ff.decide(c, si), decide(c, si)).flattenConcat() },
+    evolve = { si, ei -> ff.evolve(si, ei)(evolve(si, ei)) },
+    initialState = ff.initialState(initialState)
+)
+
+/**
+ * Product on S/State parameter - Applicative
+ *
+ * @param C Command type
+ * @param Si Input_State type
+ * @param So Output_State type
+ * @param Ei Input_Event type
+ * @param Eo Output_Event type
+ * @param Son Output_State type new
+ * @param fb
+ *
+ * @return new decider of type [InternalDecider]<[C], [Si], [Pair]<[So], [Son]>, [Ei], [Eo]>
+ */
+@FlowPreview
+@PublishedApi
+internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.productOnState(
+    fb: InternalDecider<C, Si, Son, Ei, Eo>
+): InternalDecider<C, Si, Pair<So, Son>, Ei, Eo> = applyOnState(fb.mapOnState { b: Son -> { a: So -> Pair(a, b) } })
+
+
+/**
+ * Combine [InternalDecider]s into one big [InternalDecider]
+ *
+ * Possible to use when:
+ *
+ * - [Ei] and [Ei2] have common superclass [Ei_SUPER]
+ * - [Eo] and [Eo2] have common superclass [Eo_SUPER]
+ * - [C] and [C2] have common superclass [C_SUPER]
+ *
+ * @param C Command type of the first Decider
+ * @param Si Input_State type of the first Decider
+ * @param So Output_State type of the first Decider
+ * @param Ei Input_Event type of the first Decider
+ * @param Eo Output_Event type of the first Decider
+ * @param C2 Command type of the second Decider
+ * @param Si2 Input_State type of the second Decider
+ * @param So2 Output_State type of the second Decider
+ * @param Ei2 Input_Event type of the second Decider
+ * @param Eo2 Output_Event type of the second Decider
+ * @param C_SUPER super type of the command types C and C2
+ * @param Ei_SUPER super type of the Ei and Ei2 types
+ * @param Eo_SUPER super type of the Eo and Eo2 types
+ * @param y second Decider
+ * @return [InternalDecider]<[C_SUPER], [Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [Ei_SUPER], [Eo_SUPER]>
+ */
+
+@PublishedApi
+@FlowPreview
+internal inline infix fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, reified C2 : C_SUPER, Si2, So2, reified Ei2 : Ei_SUPER, Eo2 : Eo_SUPER, C_SUPER, Ei_SUPER, Eo_SUPER> InternalDecider<C?, Si, So, Ei?, Eo?>.combine(
+    y: InternalDecider<C2?, Si2, So2, Ei2?, Eo2?>
+): InternalDecider<C_SUPER?, Pair<Si, Si2>, Pair<So, So2>, Ei_SUPER, Eo_SUPER?> {
+
+    val deciderX = this.mapLeftOnCommand<C_SUPER?> { it as? C }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.first }
+        .dimapOnEvent<Ei_SUPER, Eo_SUPER?>({ it as? Ei }, { it })
+
+    val deciderY = y.mapLeftOnCommand<C_SUPER?> { it as? C2 }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.second }
+        .dimapOnEvent<Ei_SUPER, Eo_SUPER?>({ it as? Ei2 }, { it })
+
+    return deciderX.productOnState(deciderY)
+}
+

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/InternalView.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/InternalView.kt
@@ -1,0 +1,130 @@
+package com.fraktalio.fmodel.domain
+
+/**
+ * [InternalView] is a datatype that represents the event handling algorithm,
+ * responsible for translating the events into denormalized state,
+ * which is more adequate for querying.
+ *
+ * It has three generic parameters [Si], [So], [E], representing the type of the values that [InternalView] may contain or use.
+ * [InternalView] can be specialized for any type of [Si], [So], [E] because these types does not affect its behavior.
+ * [InternalView] behaves the same for [E]=[Int] or [E]=YourCustomType, for example.
+ *
+ * [InternalView] is a pure domain component
+ *
+ * @param Si Input State type
+ * @param So Output State type
+ * @param E Event type
+ * @property evolve A pure function/lambda that takes input state of type [Si] and input event of type [E] as parameters, and returns the output/new state [So]
+ * @property initialState A starting point / An initial state of type [So]
+ * @constructor Creates [InternalView]
+ *
+ * @see [View]
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+
+@PublishedApi
+internal data class InternalView<in Si, out So, in E>(
+    val evolve: (Si, E) -> So,
+    val initialState: So,
+) {
+    /**
+     * Left map on E/Event parameter - Contravariant
+     *
+     * @param En Event new
+     * @param f
+     */
+    inline fun <En> mapLeftOnEvent(
+        crossinline f: (En) -> E
+    ): InternalView<Si, So, En> = InternalView(
+        evolve = { si, en -> evolve(si, f(en)) },
+        initialState = initialState
+    )
+
+    /**
+     * Dimap on S/State parameter - Contravariant on the Si (input State) - Covariant on the So (output State) = Profunctor
+     *
+     * @param Sin State input new
+     * @param Son State output new
+     * @param fl
+     * @param fr
+     */
+    inline fun <Sin, Son> dimapOnState(
+        crossinline fl: (Sin) -> Si, crossinline fr: (So) -> Son
+    ): InternalView<Sin, Son, E> = InternalView(
+        evolve = { sin, e -> fr(evolve(fl(sin), e)) },
+        initialState = fr(initialState)
+    )
+
+    /**
+     * Left map on S/State parameter - Contravariant
+     *
+     * @param Sin State input new
+     * @param f
+     */
+    inline fun <Sin> mapLeftOnState(crossinline f: (Sin) -> Si): InternalView<Sin, So, E> = dimapOnState(f) { it }
+
+    /**
+     * Right map on S/State parameter - Covariant
+     *
+     * @param Son State output new
+     * @param f
+     */
+    inline fun <Son> mapOnState(crossinline f: (So) -> Son): InternalView<Si, Son, E> = dimapOnState({ it }, f)
+}
+
+/**
+ * Apply on S/State parameter - Applicative
+ *
+ * @param Si State input type
+ * @param So State output type
+ * @param E Event type
+ * @param Son State output new type
+ * @param ff
+ */
+internal fun <Si, So, E, Son> InternalView<Si, So, E>.applyOnState(
+    ff: InternalView<Si, (So) -> Son, E>
+): InternalView<Si, Son, E> = InternalView(
+    evolve = { si, e -> ff.evolve(si, e)(evolve(si, e)) },
+    initialState = ff.initialState(initialState)
+)
+
+/**
+ * Product on S/State parameter - Applicative
+ *
+ * @param Si State input type
+ * @param So State output type
+ * @param E Event type
+ * @param Son State output new type
+ * @param fb
+ */
+@PublishedApi
+internal fun <Si, So, E, Son> InternalView<Si, So, E>.productOnState(fb: InternalView<Si, Son, E>): InternalView<Si, Pair<So, Son>, E> =
+    applyOnState(fb.mapOnState { b: Son -> { a: So -> Pair(a, b) } })
+
+/**
+ * Combines [InternalView]s into one bigger [InternalView]
+ *
+ * Possible to use when [E] and [E2] have common superclass [E_SUPER]
+ *
+ * @param Si State input of the first View
+ * @param So State output of the first View
+ * @param E Event of the first View
+ * @param Si2 State input of the second View
+ * @param So2 State output of the second View
+ * @param E2 Event of the second View
+ * @param E_SUPER super type for [E] and [E2]
+ * @param y second View
+ * @return new View of type [InternalView]<[Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [E_SUPER]>
+ */
+@PublishedApi
+internal inline infix fun <Si, So, reified E : E_SUPER, Si2, So2, reified E2 : E_SUPER, E_SUPER> InternalView<Si, So, E?>.combine(
+    y: InternalView<Si2, So2, E2?>
+): InternalView<Pair<Si, Si2>, Pair<So, So2>, E_SUPER> {
+
+    val viewX = this.mapLeftOnEvent<E_SUPER> { it as? E }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.first }
+
+    val viewY = y.mapLeftOnEvent<E_SUPER> { it as? E2 }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.second }
+
+    return viewX.productOnState(viewY)
+}

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/View.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/View.kt
@@ -17,31 +17,16 @@
 package com.fraktalio.fmodel.domain
 
 /**
- * An interface of the [_View]
- *
- * @param Si Input State type
- * @param So Output State type
- * @param E Event type
- *
- * @see [IView]
+ * View interface
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-interface I_View<in Si, out So, in E> {
-    val evolve: (Si, E) -> So
-    val initialState: So
+interface IView<S, in E> {
+    val evolve: (S, E) -> S
+    val initialState: S
 }
 
 /**
- * A convenient typealias for the [I_View] interface. It is specializing the three parameters [I_View] interface to only two parameters interface [IView].
- *
- * @author Иван Дугалић / Ivan Dugalic / @idugalic
- */
-typealias IView<S, E> = I_View<S, S, E>
-
-/**
- * A typealias for [_View]<Si, So, E>, specializing the [_View] to two generic parameters: S and E, where Si=S, So=S, E=E
- *
  * [View] is a datatype that represents the event handling algorithm,
  * responsible for translating the events into denormalized state,
  * which is more adequate for querying.
@@ -53,9 +38,58 @@ typealias IView<S, E> = I_View<S, S, E>
  * @param S State type
  * @param E Event type
  *
- * @author Иванугалић / Ivan Dugalic / @idugalic
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-typealias View<S, E> = _View<S, S, E>
+data class View<S, in E>(
+    override val evolve: (S, E) -> S,
+    override val initialState: S
+) : IView<S, E> {
+    @PublishedApi
+    internal constructor(view: InternalView<S, S, E>) : this(view.evolve, view.initialState)
+
+    /**
+     * Left map on E/Event
+     *
+     * @param En Event new
+     * @param f Function that maps type `En` to `E`
+     *
+     * @return New View of type [View]<[S], [En]>
+     */
+    inline fun <En> mapLeftOnEvent(
+        crossinline f: (En) -> E
+    ): View<S, En> = View(InternalView(evolve, initialState).mapLeftOnEvent(f))
+
+    /**
+     * Di-map on S/State
+     *
+     * @param Sn State new
+     * @param fl Function that maps type `Sn` to `S`
+     * @param fr Function that maps type `S` to `Sn`
+     *
+     * @return New View of type [View]<[Sn], [E]>
+     */
+    inline fun <Sn> dimapOnState(
+        crossinline fl: (Sn) -> S,
+        crossinline fr: (S) -> Sn
+    ): View<Sn, E> = View(InternalView(evolve, initialState).dimapOnState(fl, fr))
+
+}
+
+/**
+ * Combines [View]s into one [View]
+ *
+ * Possible to use when [E] and [E2] have common superclass [E_SUPER]
+ *
+ * @param S State  of the first View
+ * @param E Event of the first View
+ * @param S2 State of the second View
+ * @param E2 Event of the second View
+ * @param E_SUPER super type for [E] and [E2]
+ * @param y second View
+ * @return new View of type [View]<[Pair]<[S], [S2]>, [E_SUPER]>
+ */
+inline infix fun <S, reified E : E_SUPER, S2, reified E2 : E_SUPER, E_SUPER> View<S, E?>.combine(y: View<S2, E2?>): View<Pair<S, S2>, E_SUPER> =
+    View(InternalView(evolve, initialState).combine(InternalView(y.evolve, y.initialState)))
 
 /**
  * View DSL - A convenient builder DSL for the [View]
@@ -79,132 +113,4 @@ class ViewBuilder<S, E> internal constructor() {
     }
 
     fun build(): View<S, E> = View(evolve, initialState())
-}
-
-/**
- * [_View] is a datatype that represents the event handling algorithm,
- * responsible for translating the events into denormalized state,
- * which is more adequate for querying.
- *
- * It has three generic parameters [Si], [So], [E], representing the type of the values that [_View] may contain or use.
- * [_View] can be specialized for any type of [Si], [So], [E] because these types does not affect its behavior.
- * [_View] behaves the same for [E]=[Int] or [E]=YourCustomType, for example.
- *
- * [_View] is a pure domain component
- *
- * @param Si Input State type
- * @param So Output State type
- * @param E Event type
- * @property evolve A pure function/lambda that takes input state of type [Si] and input event of type [E] as parameters, and returns the output/new state [So]
- * @property initialState A starting point / An initial state of type [So]
- * @constructor Creates [_View]
- *
- * @see [View]
- *
- * @author Иван Дугалић / Ivan Dugalic / @idugalic
- */
-data class _View<in Si, out So, in E>(
-    override val evolve: (Si, E) -> So,
-    override val initialState: So,
-) : I_View<Si, So, E> {
-    /**
-     * Left map on E/Event parameter - Contravariant
-     *
-     * @param En Event new
-     * @param f
-     */
-    inline fun <En> mapLeftOnEvent(
-        crossinline f: (En) -> E
-    ): _View<Si, So, En> = _View(
-        evolve = { si, en -> evolve(si, f(en)) },
-        initialState = initialState
-    )
-
-    /**
-     * Dimap on S/State parameter - Contravariant on the Si (input State) - Covariant on the So (output State) = Profunctor
-     *
-     * @param Sin State input new
-     * @param Son State output new
-     * @param fl
-     * @param fr
-     */
-    @PublishedApi
-    internal inline fun <Sin, Son> dimapOnState(
-        crossinline fl: (Sin) -> Si, crossinline fr: (So) -> Son
-    ): _View<Sin, Son, E> = _View(
-        evolve = { sin, e -> fr(evolve(fl(sin), e)) },
-        initialState = fr(initialState)
-    )
-
-    /**
-     * Left map on S/State parameter - Contravariant
-     *
-     * @param Sin State input new
-     * @param f
-     */
-    @PublishedApi
-    internal inline fun <Sin> mapLeftOnState(crossinline f: (Sin) -> Si): _View<Sin, So, E> = dimapOnState(f) { it }
-
-    /**
-     * Right map on S/State parameter - Covariant
-     *
-     * @param Son State output new
-     * @param f
-     */
-    inline fun <Son> mapOnState(crossinline f: (So) -> Son): _View<Si, Son, E> = dimapOnState({ it }, f)
-}
-
-/**
- * Apply on S/State parameter - Applicative
- *
- * @param Si State input type
- * @param So State output type
- * @param E Event type
- * @param Son State output new type
- * @param ff
- */
-internal fun <Si, So, E, Son> _View<Si, So, E>.applyOnState(
-    ff: _View<Si, (So) -> Son, E>
-): _View<Si, Son, E> = _View(
-    evolve = { si, e -> ff.evolve(si, e)(evolve(si, e)) },
-    initialState = ff.initialState(initialState)
-)
-
-/**
- * Product on S/State parameter - Applicative
- *
- * @param Si State input type
- * @param So State output type
- * @param E Event type
- * @param Son State output new type
- * @param fb
- */
-@PublishedApi
-internal fun <Si, So, E, Son> _View<Si, So, E>.productOnState(fb: _View<Si, Son, E>): _View<Si, Pair<So, Son>, E> =
-    applyOnState(fb.mapOnState { b: Son -> { a: So -> Pair(a, b) } })
-
-/**
- * Combines [_View]s into one bigger [_View]
- *
- * Possible to use when [E] and [E2] have common superclass [E_SUPER]
- *
- * @param Si State input of the first View
- * @param So State output of the first View
- * @param E Event of the first View
- * @param Si2 State input of the second View
- * @param So2 State output of the second View
- * @param E2 Event of the second View
- * @param E_SUPER super type for [E] and [E2]
- * @param y second View
- * @return new View of type [_View]<[Pair]<[Si], [Si2]>, [Pair]<[So], [So2]>, [E_SUPER]>
- */
-inline infix fun <Si, So, reified E : E_SUPER, Si2, So2, reified E2 : E_SUPER, E_SUPER> _View<Si, So, E?>.combine(
-    y: _View<Si2, So2, E2?>
-): _View<Pair<Si, Si2>, Pair<So, So2>, E_SUPER> {
-
-    val viewX = this.mapLeftOnEvent<E_SUPER> { it as? E }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.first }
-
-    val viewY = y.mapLeftOnEvent<E_SUPER> { it as? E2 }.mapLeftOnState<Pair<Si, Si2>> { pair -> pair.second }
-
-    return viewX.productOnState(viewY)
 }


### PR DESCRIPTION
Minimizing the public API of the Domain

 - `_Decider<C, Si, So, Ei, Eo>` is internal now
 - `_View<Si, So, E>` is internal now
 
There was no true usage of this API, so we have chosen to make it internal, in favor of `Decider<C, S, E>` and `View<S, E>`

We hope to minimize the complexity of the API.

If you find that you need this API, please let us know!
