### PR TITLE
Application interfaces simplified (unused methods deleted)

### DIFF
--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberLockingRepository.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/even/command/EvenNumberLockingRepository.kt
@@ -20,9 +20,7 @@ import com.fraktalio.fmodel.application.EventLockingRepository
 import com.fraktalio.fmodel.application.LatestVersionProvider
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberCommand.EvenNumberCommand
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 
 /**
  * A very simple event store ;)  It is initially empty.
@@ -40,25 +38,24 @@ class EvenNumberLockingRepository : EventLockingRepository<EvenNumberCommand?, N
 
         evenNumberEventStorage.asFlow()
 
-    override suspend fun NumberEvent.EvenNumberEvent?.save(latestVersion: Pair<NumberEvent.EvenNumberEvent?, Long?>?): Pair<NumberEvent.EvenNumberEvent?, Long?> {
-        val (_, version) = latestVersion ?: Pair(null, null)
-        val result = Pair(this, if (version != null) version + 1 else 1)
-
-        evenNumberEventStorage = evenNumberEventStorage.plus(result)
-
-        return result
-    }
 
     override val latestVersionProvider: LatestVersionProvider<NumberEvent.EvenNumberEvent?, Long?> =
         { evenNumberEventStorage.last() }
 
 
     override fun Flow<NumberEvent.EvenNumberEvent?>.save(latestVersion: Pair<NumberEvent.EvenNumberEvent?, Long?>?): Flow<Pair<NumberEvent.EvenNumberEvent?, Long?>> =
-        map { it.save(latestVersion) }
+        map {
+            val (_, version) = latestVersion ?: Pair(null, null)
+            val result = Pair(it, if (version != null) version + 1 else 1)
+            evenNumberEventStorage = evenNumberEventStorage.plus(result)
+            result
+        }
 
 
     override fun Flow<NumberEvent.EvenNumberEvent?>.save(latestVersionProvider: LatestVersionProvider<NumberEvent.EvenNumberEvent?, Long?>): Flow<Pair<NumberEvent.EvenNumberEvent?, Long?>> =
-        map { it.save(latestVersionProvider) }
+        flow {
+            emitAll(save(latestVersionProvider(this@save.first())))
+        }
 
     fun deleteAll() {
         evenNumberEventStorage = emptyList()

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/ActionPublisher.kt
@@ -17,7 +17,6 @@
 package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 
 /**
  * Action publisher interface
@@ -29,13 +28,6 @@ import kotlinx.coroutines.flow.map
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 interface ActionPublisher<A> {
-    /**
-     * Publish action
-     *
-     * @receiver Action of type [A]
-     * @return newly published Action of type [A]
-     */
-    suspend fun A.publish(): A
 
     /**
      * Publish actions
@@ -43,5 +35,5 @@ interface ActionPublisher<A> {
      * @receiver [Flow] of Actions of type [A]
      * @return [Flow] of newly published Actions of type [A]
      */
-    fun Flow<A>.publish(): Flow<A> = map { it.publish() }
+    fun Flow<A>.publish(): Flow<A>
 }

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventRepository.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventRepository.kt
@@ -17,8 +17,6 @@
 package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 
 /**
  * Event repository interface
@@ -37,14 +35,6 @@ interface EventRepository<C, E> {
      * @return [Flow] of Events of type [E]
      */
     fun C.fetchEvents(): Flow<E>
-
-    /**
-     * Save event
-     *
-     * @receiver Event of type [E]
-     * @return newly saved Event of type [E]
-     */
-    suspend fun E.save(): E = flowOf(this).save().first()
 
     /**
      * Save events
@@ -91,26 +81,6 @@ interface EventLockingRepository<C, E, V> {
      * The latest event stream version provider
      */
     val latestVersionProvider: LatestVersionProvider<E, V>
-
-
-    /**
-     * Save event
-     *
-     * @param latestVersionProvider The latest event stream version provider
-     * @receiver Event of type [E]
-     * @return newly saved Event of type [Pair]<[E], [V]>
-     */
-    suspend fun E.save(latestVersionProvider: LatestVersionProvider<E, V>): Pair<E, V> =
-        save(latestVersionProvider(this))
-
-    /**
-     * Save event
-     *
-     * @param latestVersion The latest event stream version
-     * @receiver Event of type [E]
-     * @return newly saved Event of type [Pair]<[E], [V]>
-     */
-    suspend fun E.save(latestVersion: Pair<E, V>?): Pair<E, V> = flowOf(this).save(latestVersionProvider).first()
 
     /**
      * Save events


### PR DESCRIPTION
EventRepository interface in the application module has been simplified by removing 

`fun E.save():E`

Function `fun Flow<E>.save(): Flow<E>` should be good enough. 