### PR TITLE
Publish multiple (native) targets

### DIFF
--- a/.github/workflows/gradle-test-build-publish.yml
+++ b/.github/workflows/gradle-test-build-publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'macos-11', 'ubuntu-latest', 'windows-latest' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -33,19 +33,19 @@ jobs:
           java-version: '17'
           check-latest: true
 
-      - name: Publish JVM, JS and Linux versions
+      - name: Publish JVM, JS and MacOS versions
         uses: gradle/gradle-build-action@v2.3.3
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macos-11'
         with:
           cache-disabled: true
           arguments: --full-stacktrace test publishAllPublicationToOssrhRepository
 
-      - name: Publish MacOS version
+      - name: Publish Linux version
         uses: gradle/gradle-build-action@v2.3.3
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         with:
           cache-disabled: true
-          arguments: --full-stacktrace macosX64Test publishMacosX64PublicationToOssrhRepository
+          arguments: --full-stacktrace linuxX64Test publishLinuxX64PublicationToOssrhRepository
 
       - name: Publish Windows version
         uses: gradle/gradle-build-action@v2.3.3

--- a/.github/workflows/gradle-test-build.yml
+++ b/.github/workflows/gradle-test-build.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'macos-11', 'ubuntu-latest', 'windows-latest' ]
 
     steps:
       - name: Checkout
@@ -29,17 +29,17 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
-      - name: Test (linux, jvm, js)
+      - name: Test (macos, jvm, js)
         uses: gradle/gradle-build-action@v2.3.3
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'macos-11'
         with:
           arguments: --full-stacktrace build
 
-      - name: Test (macos)
+      - name: Test (linux)
         uses: gradle/gradle-build-action@v2.3.3
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'ubuntu-latest'
         with:
-          arguments: --full-stacktrace macosX64Test
+          arguments: --full-stacktrace linuxX64Test
 
       - name: Test (windows)
         uses: gradle/gradle-build-action@v2.3.3

--- a/application-arrow/build.gradle.kts
+++ b/application-arrow/build.gradle.kts
@@ -9,57 +9,33 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "17"
-            kotlinOptions.verbose = true
-        }
+    jvm()
 
-        withJava()
-        testRuns["test"].executionTask.configure {
-            useJUnitPlatform()
-            filter {
-                isFailOnNoMatchingTests = false
-            }
-            testLogging {
-                showExceptions = true
-                showStandardStreams = true
-                events = setOf(
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
-                )
-                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-            }
-        }
-    }
     js(IR) {
-        compilations.all {
-            kotlinOptions.verbose = true
-            kotlinOptions.sourceMap = true
-        }
         browser()
         nodejs()
     }
-    val hostOs = System.getProperty("os.name")
-    val arch = System.getProperty("os.arch")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" ->
-            when {
-                arch == "aarch64" || arch.startsWith("arm") -> macosArm64()
-                else -> macosX64()
-            }
 
-        hostOs == "Linux" -> linuxX64()
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-    nativeTarget.compilations.all {
-        kotlinOptions.verbose = true
-    }
-    nativeTarget.binaries.all {
-        freeCompilerArgs += "-Xlazy-ir-for-caches=disable"
-    }
+    linuxX64()
+
+    mingwX64()
+
+    macosX64()
+    macosArm64()
+
+    tvos()
+    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    watchosSimulatorArm64()
+
+    iosX64()
+    iosArm64()
+    iosArm32()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {

--- a/application-vanilla/build.gradle.kts
+++ b/application-vanilla/build.gradle.kts
@@ -9,57 +9,33 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "17"
-            kotlinOptions.verbose = true
-        }
+    jvm()
 
-        withJava()
-        testRuns["test"].executionTask.configure {
-            useJUnitPlatform()
-            filter {
-                isFailOnNoMatchingTests = false
-            }
-            testLogging {
-                showExceptions = true
-                showStandardStreams = true
-                events = setOf(
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
-                )
-                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-            }
-        }
-    }
     js(IR) {
-        compilations.all {
-            kotlinOptions.verbose = true
-            kotlinOptions.sourceMap = true
-        }
         browser()
         nodejs()
     }
-    val hostOs = System.getProperty("os.name")
-    val arch = System.getProperty("os.arch")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" ->
-            when {
-                arch == "aarch64" || arch.startsWith("arm") -> macosArm64()
-                else -> macosX64()
-            }
 
-        hostOs == "Linux" -> linuxX64()
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-    nativeTarget.compilations.all {
-        kotlinOptions.verbose = true
-    }
-    nativeTarget.binaries.all {
-        freeCompilerArgs += "-Xlazy-ir-for-caches=disable"
-    }
+    linuxX64()
+
+    mingwX64()
+
+    macosX64()
+    macosArm64()
+
+    tvos()
+    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    watchosSimulatorArm64()
+
+    iosX64()
+    iosArm64()
+    iosArm32()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -8,35 +8,34 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "17"
-        }
-    }
+    jvm()
+
     js(IR) {
         browser()
         nodejs()
     }
-    val hostOs = System.getProperty("os.name")
-    val arch = System.getProperty("os.arch")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" ->
-            when {
-                arch == "aarch64" || arch.startsWith("arm") -> macosArm64()
-                else -> macosX64()
-            }
 
-        hostOs == "Linux" -> linuxX64()
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-    nativeTarget.compilations.all {
-        kotlinOptions.verbose = true
-    }
-    nativeTarget.binaries.all {
-        freeCompilerArgs += "-Xlazy-ir-for-caches=disable"
-    }
+    linuxX64()
+
+    mingwX64()
+
+    macosX64()
+    macosArm64()
+
+    tvos()
+    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    watchosSimulatorArm64()
+
+    iosX64()
+    iosArm64()
+    iosArm32()
+    iosSimulatorArm64()
+
     sourceSets {
         val commonMain by getting {
             dependencies {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -9,56 +9,33 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
-    jvm {
-        compilations.all {
-            kotlinOptions.jvmTarget = "17"
-            kotlinOptions.verbose = true
-        }
-        //withJava()
-        testRuns["test"].executionTask.configure {
-            useJUnitPlatform()
-            filter {
-                isFailOnNoMatchingTests = false
-            }
-            testLogging {
-                showExceptions = true
-                showStandardStreams = true
-                events = setOf(
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
-                    org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
-                )
-                exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-            }
-        }
-    }
+    jvm()
+
     js(IR) {
-        compilations.all {
-            kotlinOptions.verbose = true
-            kotlinOptions.sourceMap = true
-        }
         browser()
         nodejs()
     }
-    val hostOs = System.getProperty("os.name")
-    val arch = System.getProperty("os.arch")
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" ->
-            when {
-                arch == "aarch64" || arch.startsWith("arm") -> macosArm64()
-                else -> macosX64()
-            }
 
-        hostOs == "Linux" -> linuxX64()
-        isMingwX64 -> mingwX64()
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
-    nativeTarget.compilations.all {
-        kotlinOptions.verbose = true
-    }
-    nativeTarget.binaries.all {
-        freeCompilerArgs += "-Xlazy-ir-for-caches=disable"
-    }
+    linuxX64()
+
+    mingwX64()
+
+    macosX64()
+    macosArm64()
+
+    tvos()
+    tvosSimulatorArm64()
+
+    watchosArm32()
+    watchosArm64()
+    watchosX86()
+    watchosX64()
+    watchosSimulatorArm64()
+
+    iosX64()
+    iosArm64()
+    iosArm32()
+    iosSimulatorArm64()
 
     sourceSets {
         val commonMain by getting {
@@ -72,7 +49,6 @@ kotlin {
                 implementation(libs.kotest.assertionsCore)
             }
         }
-        //  val jvmMain by getting
         val jvmTest by getting {
             dependencies {
                 runtimeOnly(libs.kotest.runnerJUnit5)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,4 @@
 kotlin.code.style=official
-kotlin.js.generate.executable.default=false
 kotlin.mpp.stability.nowarn=true
-#kotlin.native.ignoreDisabledTargets=true
 kotlin.incremental=true
-# Kotlin Test configuration
-kotest.framework.parallelism=1
 org.gradle.jvmargs=-Xmx1024m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 coroutines = "1.6.4"
 dokka = "1.7.20"
-kotest = "5.5.5"
-kotest-plugin = "5.5.5"
+kotest = "5.5.4"
+kotest-plugin = "5.5.4"
 kotlin = "1.8.10"
 arrow = "1.1.5"
 


### PR DESCRIPTION
Introducing more native targets to be published to maven central:

    linuxX64()

    mingwX64()

    macosX64()
    macosArm64()

    tvos()
    tvosSimulatorArm64()

    watchosArm32()
    watchosArm64()
    watchosX86()
    watchosX64()
    watchosSimulatorArm64()

    iosX64()
    iosArm64()
    iosArm32()
    iosSimulatorArm64()