### PR TITLE
Nodejs - Apple Silicon build/config fixed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,3 @@ allprojects {
     }
 }
 
-//  see the issue: https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5381158.0-0
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin> {
-    rootProject.the<org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension>().nodeVersion = "16.13.1"
-}


### PR DESCRIPTION
The issue (https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5381158.0-0) is fixed in Kotlin 1.6.20M1.

Proven to work on Kotlin 1.8.0 version. It could be that it works with previous versions (1.7.*) as well, but we have not checked that. 