### PR TITLE
Kotlin upgraded to 1.8.20

### DIFF
--- a/application-arrow/build.gradle.kts
+++ b/application-arrow/build.gradle.kts
@@ -28,13 +28,11 @@ kotlin {
 
     watchosArm32()
     watchosArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
     iosX64()
     iosArm64()
-    iosArm32()
     iosSimulatorArm64()
 
     sourceSets {

--- a/application-vanilla/build.gradle.kts
+++ b/application-vanilla/build.gradle.kts
@@ -28,13 +28,11 @@ kotlin {
 
     watchosArm32()
     watchosArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
     iosX64()
     iosArm64()
-    iosArm32()
     iosSimulatorArm64()
 
     sourceSets {

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -27,13 +27,11 @@ kotlin {
 
     watchosArm32()
     watchosArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
     iosX64()
     iosArm64()
-    iosArm32()
     iosSimulatorArm64()
 
     sourceSets {

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -28,13 +28,11 @@ kotlin {
 
     watchosArm32()
     watchosArm64()
-    watchosX86()
     watchosX64()
     watchosSimulatorArm64()
 
     iosX64()
     iosArm64()
-    iosArm32()
     iosSimulatorArm64()
 
     sourceSets {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ coroutines = "1.6.4"
 dokka = "1.8.10"
 kotest = "5.5.4"
 kotest-plugin = "5.5.4"
-kotlin = "1.8.10"
+kotlin = "1.8.20"
 arrow = "1.2.0-RC"
 
 [libraries]


### PR DESCRIPTION
Kotlin upgraded to 1.8.20

 - Additionally, deprecated targets are removed