### PR TITLE
Deprecating factory functions in favour of constructor-like functions.

### DIFF
--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
@@ -64,9 +64,6 @@ interface EventOrchestratingComputation<C, S, E> : ISaga<E, C>, IDecider<C, S, E
  * [EventSourcingAggregate] extends [EventComputation] and [EventRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
  *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [eventSourcingAggregate] function is a good example.
- *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that this aggregate can publish
@@ -88,9 +85,6 @@ interface EventSourcingAggregate<C, S, E> : EventComputation<C, S, E>, EventRepo
  * [EventSourcingLockingAggregate] extends [EventComputation] and [EventLockingRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
  *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [eventSourcingLockingAggregate] function is a good example.
- *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that this aggregate can publish
@@ -109,9 +103,6 @@ interface EventSourcingLockingAggregate<C, S, E, V> : EventComputation<C, S, E>,
  *
  * [EventSourcingOrchestratingAggregate] extends [EventOrchestratingComputation] and [EventRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
- *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [eventSourcingOrchestratingAggregate] function is a good example.
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
@@ -135,9 +126,6 @@ interface EventSourcingOrchestratingAggregate<C, S, E> : EventOrchestratingCompu
  *
  * [EventSourcingLockingOrchestratingAggregate] extends [EventOrchestratingComputation] and [EventLockingRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
- *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [eventSourcingLockingAggregate] function is a good example.
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
@@ -164,7 +152,33 @@ interface EventSourcingLockingOrchestratingAggregate<C, S, E, V> : EventOrchestr
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use EventSourcingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("EventSourcingAggregate(decider, eventRepository)")
+)
 fun <C, S, E> eventSourcingAggregate(
+    decider: IDecider<C, S, E>,
+    eventRepository: EventRepository<C, E>
+): EventSourcingAggregate<C, S, E> =
+    object : EventSourcingAggregate<C, S, E>,
+        EventRepository<C, E> by eventRepository,
+        IDecider<C, S, E> by decider {}
+
+/**
+ * Event Sourced aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param eventRepository An aggregate event repository of type [EventRepository]<[C], [E]>
+ * @return An object/instance of type [EventSourcingAggregate]<[C], [S], [E]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E> EventSourcingAggregate(
     decider: IDecider<C, S, E>,
     eventRepository: EventRepository<C, E>
 ): EventSourcingAggregate<C, S, E> =
@@ -187,7 +201,34 @@ fun <C, S, E> eventSourcingAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use EventSourcingLockingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("EventSourcingLockingAggregate(decider, eventRepository)")
+)
 fun <C, S, E, V> eventSourcingLockingAggregate(
+    decider: IDecider<C, S, E>,
+    eventRepository: EventLockingRepository<C, E, V>
+): EventSourcingLockingAggregate<C, S, E, V> =
+    object : EventSourcingLockingAggregate<C, S, E, V>,
+        EventLockingRepository<C, E, V> by eventRepository,
+        IDecider<C, S, E> by decider {}
+
+/**
+ * Event Sourced Locking aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param V Version
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param eventRepository An aggregate event repository of type [EventLockingRepository]<[C], [E], [V]>
+ * @return An object/instance of type [EventSourcingLockingAggregate]<[C], [S], [E], [V]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E, V> EventSourcingLockingAggregate(
     decider: IDecider<C, S, E>,
     eventRepository: EventLockingRepository<C, E, V>
 ): EventSourcingLockingAggregate<C, S, E, V> =
@@ -210,7 +251,36 @@ fun <C, S, E, V> eventSourcingLockingAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use EventSourcingOrchestratingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("EventSourcingOrchestratingAggregate(decider, eventRepository, saga)")
+)
 fun <C, S, E> eventSourcingOrchestratingAggregate(
+    decider: IDecider<C, S, E>,
+    eventRepository: EventRepository<C, E>,
+    saga: ISaga<E, C>
+): EventSourcingOrchestratingAggregate<C, S, E> =
+    object : EventSourcingOrchestratingAggregate<C, S, E>,
+        EventRepository<C, E> by eventRepository,
+        IDecider<C, S, E> by decider,
+        ISaga<E, C> by saga {}
+
+/**
+ * Event Sourced Orchestrating aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param eventRepository An aggregate event repository of type [EventRepository]<[C], [E]>
+ * @param saga A saga component of type [ISaga]<[E], [C]> - orchestrates the deciders
+ * @return An object/instance of type [EventSourcingOrchestratingAggregate]<[C], [S], [E]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E> EventSourcingOrchestratingAggregate(
     decider: IDecider<C, S, E>,
     eventRepository: EventRepository<C, E>,
     saga: ISaga<E, C>
@@ -236,7 +306,38 @@ fun <C, S, E> eventSourcingOrchestratingAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use EventSourcingLockingOrchestratingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("EventSourcingLockingOrchestratingAggregate(decider, eventRepository, saga)")
+)
 fun <C, S, E, V> eventSourcingLockingOrchestratingAggregate(
+    decider: IDecider<C, S, E>,
+    eventRepository: EventLockingRepository<C, E, V>,
+    saga: ISaga<E, C>
+): EventSourcingLockingOrchestratingAggregate<C, S, E, V> =
+    object : EventSourcingLockingOrchestratingAggregate<C, S, E, V>,
+        EventLockingRepository<C, E, V> by eventRepository,
+        IDecider<C, S, E> by decider,
+        ISaga<E, C> by saga {}
+
+/**
+ * Event Sourced Locking Orchestrating aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param V Version
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param eventRepository An aggregate event repository of type [EventLockingRepository]<[C], [E], [V]>
+ * @param saga A saga component of type [ISaga]<[E], [C]> - orchestrates the deciders
+ * @return An object/instance of type [EventSourcingLockingOrchestratingAggregate]<[C], [S], [E] ,[V]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+
+fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate(
     decider: IDecider<C, S, E>,
     eventRepository: EventLockingRepository<C, E, V>,
     saga: ISaga<E, C>

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/MaterializedView.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/MaterializedView.kt
@@ -87,6 +87,10 @@ interface MaterializedLockingDeduplicationView<S, E, EV, SV> : ViewStateComputat
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use MaterializedView constructor-like function instead",
+    replaceWith = ReplaceWith("MaterializedView(view, viewStateRepository)")
+)
 fun <S, E> materializedView(
     view: IView<S, E>,
     viewStateRepository: ViewStateRepository<E, S>,
@@ -94,6 +98,28 @@ fun <S, E> materializedView(
     object : MaterializedView<S, E>,
         ViewStateRepository<E, S> by viewStateRepository,
         IView<S, E> by view {}
+
+/**
+ * Materialized View constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @property view A view component of type [IView]<[S], [E]>
+ * @property viewStateRepository Interface for [S]tate management/persistence - dependencies by delegation
+ * @return An object/instance of type [MaterializedView]<[S], [E]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <S, E> MaterializedView(
+    view: IView<S, E>,
+    viewStateRepository: ViewStateRepository<E, S>,
+): MaterializedView<S, E> =
+    object : MaterializedView<S, E>,
+        ViewStateRepository<E, S> by viewStateRepository,
+        IView<S, E> by view {}
+
 
 /**
  * Materialized Locking View factory function.
@@ -109,7 +135,33 @@ fun <S, E> materializedView(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use MaterializedLockingView constructor-like function instead",
+    replaceWith = ReplaceWith("MaterializedLockingView(view, viewStateRepository)")
+)
 fun <S, E, V> materializedLockingView(
+    view: IView<S, E>,
+    viewStateRepository: ViewStateLockingRepository<E, S, V>,
+): MaterializedLockingView<S, E, V> =
+    object : MaterializedLockingView<S, E, V>,
+        ViewStateLockingRepository<E, S, V> by viewStateRepository,
+        IView<S, E> by view {}
+
+/**
+ * Materialized Locking View constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param V Version
+ * @property view A view component of type [IView]<[S], [E]>
+ * @property viewStateRepository Interface for [S]tate management/persistence - dependencies by delegation
+ * @return An object/instance of type [MaterializedLockingView]<[S], [E], [V]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <S, E, V> MaterializedLockingView(
     view: IView<S, E>,
     viewStateRepository: ViewStateLockingRepository<E, S, V>,
 ): MaterializedLockingView<S, E, V> =
@@ -132,7 +184,34 @@ fun <S, E, V> materializedLockingView(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use MaterializedLockingDeduplicationView constructor-like function instead",
+    replaceWith = ReplaceWith("MaterializedLockingDeduplicationView(view, viewStateRepository)")
+)
 fun <S, E, EV, SV> materializedLockingDeduplicationView(
+    view: IView<S, E>,
+    viewStateRepository: ViewStateLockingDeduplicationRepository<E, S, EV, SV>,
+): MaterializedLockingDeduplicationView<S, E, EV, SV> =
+    object : MaterializedLockingDeduplicationView<S, E, EV, SV>,
+        ViewStateLockingDeduplicationRepository<E, S, EV, SV> by viewStateRepository,
+        IView<S, E> by view {}
+
+/**
+ * Materialized Locking Deduplication View constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param EV Event Version
+ * @param SV State Version
+ * @property view A view component of type [IView]<[S], [E]>
+ * @property viewStateRepository Interface for [S]tate management/persistence - dependencies by delegation
+ * @return An object/instance of type [MaterializedLockingDeduplicationView]<[S], [E], [EV], [SV]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <S, E, EV, SV> MaterializedLockingDeduplicationView(
     view: IView<S, E>,
     viewStateRepository: ViewStateLockingDeduplicationRepository<E, S, EV, SV>,
 ): MaterializedLockingDeduplicationView<S, E, EV, SV> =

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManager.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManager.kt
@@ -52,7 +52,31 @@ interface SagaManager<AR, A> : ISaga<AR, A>, ActionPublisher<A> {
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use SagaManager constructor-like function instead",
+    replaceWith = ReplaceWith("SagaManager(saga, actionPublisher)")
+)
 fun <AR, A> sagaManager(
+    saga: ISaga<AR, A>,
+    actionPublisher: ActionPublisher<A>
+): SagaManager<AR, A> = object : SagaManager<AR, A>,
+    ActionPublisher<A> by actionPublisher,
+    ISaga<AR, A> by saga {}
+
+/**
+ * Saga Manager constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param AR Action Result of type [AR], Action Result is usually an Event
+ * @param A An Action of type [A] to be taken. Action is usually a Command.
+ * @property saga A saga component of type [ISaga]<[AR], [A]>
+ * @property actionPublisher Interface for publishing the Actions of type [A] - dependencies by delegation
+ * @return An object/instance of type [SagaManager]<[AR], [A]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <AR, A> SagaManager(
     saga: ISaga<AR, A>,
     actionPublisher: ActionPublisher<A>
 ): SagaManager<AR, A> = object : SagaManager<AR, A>,

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
@@ -50,10 +50,6 @@ interface StateComputation<C, S, E> : IDecider<C, S, E> {
  * [StateStoredAggregate] extends [StateComputation] and [StateRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
  *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [stateStoredAggregate] function is a good example.
- *
- *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
@@ -74,10 +70,6 @@ interface StateStoredAggregate<C, S, E> : StateComputation<C, S, E>, StateReposi
  *
  * [StateStoredAggregate] extends [StateComputation] and [StateLockingRepository] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
- *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code. [stateStoredAggregate] function is a good example.
- *
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
@@ -122,11 +114,6 @@ interface StateOrchestratingComputation<C, S, E> : ISaga<E, C>, StateComputation
  * [StateStoredOrchestratingAggregate] extends [StateOrchestratingComputation] and [StateStoredAggregate] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
  *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code.
- * [stateStoredOrchestratingAggregate] function is a good example.
- *
- *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
  * @param E Events of type [E] that are used internally to build/fold new state
@@ -148,11 +135,6 @@ interface StateStoredOrchestratingAggregate<C, S, E> : StateOrchestratingComputa
  *
  * [StateStoredOrchestratingAggregate] extends [StateOrchestratingComputation] and [StateStoredAggregate] interfaces,
  * clearly communicating that it is composed out of these two behaviours.
- *
- * The Delegation pattern has proven to be a good alternative to `implementation inheritance`,
- * and Kotlin supports it natively requiring zero boilerplate code.
- * [stateStoredOrchestratingAggregate] function is a good example.
- *
  *
  * @param C Commands of type [C] that this aggregate can handle
  * @param S Aggregate state of type [S]
@@ -178,7 +160,33 @@ interface StateStoredLockingOrchestratingAggregate<C, S, E, V> : StateOrchestrat
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use StateStoredAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("StateStoredAggregate(decider, stateRepository)")
+)
 fun <C, S, E> stateStoredAggregate(
+    decider: IDecider<C, S, E>,
+    stateRepository: StateRepository<C, S>
+): StateStoredAggregate<C, S, E> =
+    object : StateStoredAggregate<C, S, E>,
+        StateRepository<C, S> by stateRepository,
+        IDecider<C, S, E> by decider {}
+
+/**
+ * State stored aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param stateRepository An aggregate state repository of type [StateRepository]<[C], [S]>
+ * @return An object/instance of type [StateStoredAggregate]<[C], [S], [E]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E> StateStoredAggregate(
     decider: IDecider<C, S, E>,
     stateRepository: StateRepository<C, S>
 ): StateStoredAggregate<C, S, E> =
@@ -201,7 +209,34 @@ fun <C, S, E> stateStoredAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use StateStoredLockingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("StateStoredLockingAggregate(decider, stateRepository)")
+)
 fun <C, S, E, V> stateStoredLockingAggregate(
+    decider: IDecider<C, S, E>,
+    stateRepository: StateLockingRepository<C, S, V>
+): StateStoredLockingAggregate<C, S, E, V> =
+    object : StateStoredLockingAggregate<C, S, E, V>,
+        StateLockingRepository<C, S, V> by stateRepository,
+        IDecider<C, S, E> by decider {}
+
+/**
+ * State stored locking aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param V Version of the aggregate/state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param stateRepository An aggregate state repository of type [StateLockingRepository]<[C], [S], [V]>
+ * @return An object/instance of type [StateStoredLockingAggregate]<[C], [S], [E], [V]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E, V> StateStoredLockingAggregate(
     decider: IDecider<C, S, E>,
     stateRepository: StateLockingRepository<C, S, V>
 ): StateStoredLockingAggregate<C, S, E, V> =
@@ -224,7 +259,36 @@ fun <C, S, E, V> stateStoredLockingAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use StateStoredOrchestratingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("StateStoredOrchestratingAggregate(decider, stateRepository, saga)")
+)
 fun <C, S, E> stateStoredOrchestratingAggregate(
+    decider: IDecider<C, S, E>,
+    stateRepository: StateRepository<C, S>,
+    saga: ISaga<E, C>
+): StateStoredOrchestratingAggregate<C, S, E> =
+    object : StateStoredOrchestratingAggregate<C, S, E>,
+        StateRepository<C, S> by stateRepository,
+        IDecider<C, S, E> by decider,
+        ISaga<E, C> by saga {}
+
+/**
+ * State stored orchestrating aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param stateRepository An aggregate state repository of type [StateRepository]<[C], [S]>
+ * @param saga A saga component of type [ISaga]<[E], [C]>
+ * @return An object/instance of type [StateStoredOrchestratingAggregate]<[C], [S], [E]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E> StateStoredOrchestratingAggregate(
     decider: IDecider<C, S, E>,
     stateRepository: StateRepository<C, S>,
     saga: ISaga<E, C>
@@ -250,7 +314,37 @@ fun <C, S, E> stateStoredOrchestratingAggregate(
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
+@Deprecated(
+    message = "Use StateStoredLockingOrchestratingAggregate constructor-like function instead",
+    replaceWith = ReplaceWith("StateStoredLockingOrchestratingAggregate(decider, stateRepository, saga)")
+)
 fun <C, S, E, V> stateStoredLockingOrchestratingAggregate(
+    decider: IDecider<C, S, E>,
+    stateRepository: StateLockingRepository<C, S, V>,
+    saga: ISaga<E, C>
+): StateStoredLockingOrchestratingAggregate<C, S, E, V> =
+    object : StateStoredLockingOrchestratingAggregate<C, S, E, V>,
+        StateLockingRepository<C, S, V> by stateRepository,
+        IDecider<C, S, E> by decider,
+        ISaga<E, C> by saga {}
+
+/**
+ * State stored orchestrating and locking aggregate constructor-like function.
+ *
+ * The Delegation pattern has proven to be a good alternative to implementation inheritance, and Kotlin supports it natively requiring zero boilerplate code.
+ *
+ * @param C Commands of type [C] that this aggregate can handle
+ * @param S Aggregate state of type [S]
+ * @param E Events of type [E] that are used internally to build/fold new state
+ * @param V Version of the aggregate/state
+ * @param decider A decider component of type [IDecider]<[C], [S], [E]>
+ * @param stateRepository An aggregate state repository of type [StateLockingRepository]<[C], [S], [V]>
+ * @param saga A saga component of type [ISaga]<[E], [C]>
+ * @return An object/instance of type [StateStoredLockingOrchestratingAggregate]<[C], [S], [E], [V]>
+ *
+ * @author Иван Дугалић / Ivan Dugalic / @idugalic
+ */
+fun <C, S, E, V> StateStoredLockingOrchestratingAggregate(
     decider: IDecider<C, S, E>,
     stateRepository: StateLockingRepository<C, S, V>,
     saga: ISaga<E, C>


### PR DESCRIPTION
>A constructor-like function is a function whose name starts with a capital letter, so it looks like a constructor. 
 
Improves readability and makes the library and your project easier to understand, in general.

