### PR TITLE
Promote ``@FlowPreview` API to stable/experimental

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,7 @@
 ---
-name: Bug report about: Create a report to help us improve title: ''
+name:
+  Bug report about:
+    Create a report to help us improve title: ''
 labels: ''
 assignees: ''
 

--- a/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateArrowExtension.kt
+++ b/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateArrowExtension.kt
@@ -20,7 +20,6 @@ import arrow.core.Either
 import arrow.core.raise.either
 import com.fraktalio.fmodel.application.Error.CommandHandlingFailed
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 
 /**
@@ -31,7 +30,6 @@ import kotlinx.coroutines.flow.*
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handleWithEffect(command: C): Flow<Either<Error, E>> =
     command
         .fetchEvents()
@@ -49,7 +47,6 @@ fun <C, S, E> EventSourcingAggregate<C, S, E>.handleWithEffect(command: C): Flow
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handleWithEffect(command: C): Flow<Either<Error, E>> =
     command
         .fetchEvents()
@@ -66,7 +63,6 @@ fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handleWithEffect(comm
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimisticallyWithEffect(command: C): Flow<Either<Error, Pair<E, V>>> =
     flow {
         val events = command.fetchEvents()
@@ -88,7 +84,6 @@ fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimisticallyW
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOptimisticallyWithEffect(command: C): Flow<Either<Error, Pair<E, V>>> =
     command
         .fetchEvents().map { it.first }
@@ -99,67 +94,55 @@ fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOp
 
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handleWithEffect(commands: Flow<C>): Flow<Either<Error, E>> =
     commands
         .flatMapConcat { handleWithEffect(it) }
         .catch { emit(either { raise(CommandHandlingFailed(it)) }) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handleWithEffect(commands: Flow<C>): Flow<Either<Error, E>> =
     commands
         .flatMapConcat { handleWithEffect(it) }
         .catch { emit(either { raise(CommandHandlingFailed(it)) }) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimisticallyWithEffect(commands: Flow<C>): Flow<Either<Error, Pair<E, V>>> =
     commands
         .flatMapConcat { handleOptimisticallyWithEffect(it) }
         .catch { emit(either { raise(CommandHandlingFailed(it)) }) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOptimisticallyWithEffect(commands: Flow<C>): Flow<Either<Error, Pair<E, V>>> =
     commands
         .flatMapConcat { handleOptimisticallyWithEffect(it) }
         .catch { emit(either { raise(CommandHandlingFailed(it)) }) }
 
-@FlowPreview
 fun <C, E> C.publishWithEffect(aggregate: EventSourcingAggregate<C, *, E>): Flow<Either<Error, E>> =
     aggregate.handleWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> C.publishWithEffect(aggregate: EventSourcingOrchestratingAggregate<C, *, E>): Flow<Either<Error, E>> =
     aggregate.handleWithEffect(this)
 
-@FlowPreview
 fun <C, E, V> C.publishOptimisticallyWithEffect(aggregate: EventSourcingLockingAggregate<C, *, E, V>): Flow<Either<Error, Pair<E, V>>> =
     aggregate.handleOptimisticallyWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> C.publishOptimisticallyWithEffect(aggregate: EventSourcingLockingOrchestratingAggregate<C, *, E, V>): Flow<Either<Error, Pair<E, V>>> =
     aggregate.handleOptimisticallyWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> Flow<C>.publishWithEffect(aggregate: EventSourcingAggregate<C, *, E>): Flow<Either<Error, E>> =
     aggregate.handleWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> Flow<C>.publishWithEffect(aggregate: EventSourcingOrchestratingAggregate<C, *, E>): Flow<Either<Error, E>> =
     aggregate.handleWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> Flow<C>.publishOptimisticallyWithEffect(aggregate: EventSourcingLockingAggregate<C, *, E, V>): Flow<Either<Error, Pair<E, V>>> =
     aggregate.handleOptimisticallyWithEffect(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> Flow<C>.publishOptimisticallyWithEffect(aggregate: EventSourcingLockingOrchestratingAggregate<C, *, E, V>): Flow<Either<Error, Pair<E, V>>> =
     aggregate.handleOptimisticallyWithEffect(this)

--- a/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManagerArrowExtension.kt
+++ b/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManagerArrowExtension.kt
@@ -21,7 +21,6 @@ import arrow.core.raise.either
 import com.fraktalio.fmodel.application.Error.ActionResultHandlingFailed
 import com.fraktalio.fmodel.application.Error.ActionResultPublishingFailed
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flatMapConcat
@@ -51,7 +50,6 @@ fun <AR, A> SagaManager<AR, A>.handleWithEffect(actionResult: AR): Flow<Either<E
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <AR, A> SagaManager<AR, A>.handleWithEffect(actionResults: Flow<AR>): Flow<Either<Error, A>> =
     actionResults
         .flatMapConcat { handleWithEffect(it) }
@@ -78,7 +76,6 @@ fun <AR, A> AR.publishWithEffect(sagaManager: SagaManager<AR, A>): Flow<Either<E
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <AR, A> Flow<AR>.publishWithEffect(sagaManager: SagaManager<AR, A>): Flow<Either<Error, A>> =
     sagaManager.handleWithEffect(this)
 

--- a/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateArrowExtension.kt
+++ b/application-arrow/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateArrowExtension.kt
@@ -20,7 +20,6 @@ import arrow.core.Either
 import arrow.core.raise.catch
 import arrow.core.raise.either
 import com.fraktalio.fmodel.application.Error.*
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
@@ -33,7 +32,6 @@ import kotlinx.coroutines.flow.map
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, I> I.handleWithEffect(command: C): Either<Error, S> where I : StateComputation<C, S, E>,
                                                                                 I : StateRepository<C, S> {
     /**
@@ -97,7 +95,6 @@ suspend fun <C, S, E, I> I.handleWithEffect(command: C): Either<Error, S> where 
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, V, I> I.handleOptimisticallyWithEffect(command: C): Either<Error, Pair<S, V>> where I : StateComputation<C, S, E>,
                                                                                                           I : StateLockingRepository<C, S, V> {
     /**
@@ -162,7 +159,6 @@ suspend fun <C, S, E, V, I> I.handleOptimisticallyWithEffect(command: C): Either
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, I> I.handleWithEffect(commands: Flow<C>): Flow<Either<Error, S>> where I : StateComputation<C, S, E>,
                                                                                      I : StateRepository<C, S> =
     commands
@@ -177,7 +173,6 @@ fun <C, S, E, I> I.handleWithEffect(commands: Flow<C>): Flow<Either<Error, S>> w
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V, I> I.handleOptimisticallyWithEffect(commands: Flow<C>): Flow<Either<Error, Pair<S, V>>> where I : StateComputation<C, S, E>,
                                                                                                                I : StateLockingRepository<C, S, V> =
     commands
@@ -192,7 +187,6 @@ fun <C, S, E, V, I> I.handleOptimisticallyWithEffect(commands: Flow<C>): Flow<Ei
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, A> C.publishWithEffect(aggregate: A): Either<Error, S> where A : StateComputation<C, S, E>,
                                                                                    A : StateRepository<C, S> =
     aggregate.handleWithEffect(this)
@@ -205,7 +199,6 @@ suspend fun <C, S, E, A> C.publishWithEffect(aggregate: A): Either<Error, S> whe
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, V, A> C.publishOptimisticallyWithEffect(aggregate: A): Either<Error, Pair<S, V>> where A : StateComputation<C, S, E>,
                                                                                                              A : StateLockingRepository<C, S, V> =
     aggregate.handleOptimisticallyWithEffect(this)
@@ -218,7 +211,6 @@ suspend fun <C, S, E, V, A> C.publishOptimisticallyWithEffect(aggregate: A): Eit
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, A> Flow<C>.publishWithEffect(aggregate: A): Flow<Either<Error, S>> where A : StateComputation<C, S, E>,
                                                                                        A : StateRepository<C, S> =
     aggregate.handleWithEffect(this)
@@ -231,7 +223,6 @@ fun <C, S, E, A> Flow<C>.publishWithEffect(aggregate: A): Flow<Either<Error, S>>
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V, A> Flow<C>.publishOptimisticallyWithEffect(aggregate: A): Flow<Either<Error, Pair<S, V>>> where A : StateComputation<C, S, E>,
                                                                                                                  A : StateLockingRepository<C, S, V> =
     aggregate.handleOptimisticallyWithEffect(this)

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateTest.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateTest.kt
@@ -20,14 +20,12 @@ import com.fraktalio.fmodel.domain.examples.numbers.odd.command.oddNumberDecider
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 
 /**
  * DSL - Given
  */
-@FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
     repository: EventRepository<C, E>,
     command: () -> C
@@ -37,7 +35,6 @@ private fun <C, S, E> IDecider<C, S, E>.given(
         eventRepository = repository
     ).handleWithEffect(command())
 
-@FlowPreview
 private fun <C, S, E, V> IDecider<C, S, E>.given(
     repository: EventLockingRepository<C, E, V>,
     command: () -> C
@@ -66,7 +63,6 @@ private suspend infix fun <E, V> Flow<Either<Error, Pair<E, V>>>.thenEventPairs(
  * Event sourced aggregate test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@FlowPreview
 class EventSourcedAggregateTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
@@ -20,12 +20,10 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 /**
  * DSL - Given
  */
-@FlowPreview
 private suspend fun <C, S, E> IDecider<C, S, E>.given(
     repository: StateRepository<C, S>,
     command: () -> C
@@ -35,7 +33,6 @@ private suspend fun <C, S, E> IDecider<C, S, E>.given(
         stateRepository = repository
     ).handleWithEffect(command())
 
-@FlowPreview
 private suspend fun <C, S, E, V> IDecider<C, S, E>.given(
     repository: StateLockingRepository<C, S, V>,
     command: () -> C
@@ -83,7 +80,6 @@ private fun <S> Either<Error, S>.thenError() {
  * State-stored aggregate test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@FlowPreview
 class StateStoredAggregateTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
@@ -29,7 +29,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -42,7 +41,7 @@ import kotlinx.coroutines.FlowPreview
  * @param repository the event-sourcing repository for all (even and odd) numbers
  * @return the event-sourcing aggregate instance for all (even and odd) numbers
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun numberAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
+++ b/application-arrow/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
@@ -29,7 +29,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -42,7 +41,7 @@ import kotlinx.coroutines.FlowPreview
  * @param repository the state-stored repository for all (even and odd) numbers
  * @return the state-stored aggregate instance for all (even and odd) numbers
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun numberStateStoredAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateExtension.kt
+++ b/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateExtension.kt
@@ -17,7 +17,6 @@
 package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 
 /**
@@ -28,7 +27,6 @@ import kotlinx.coroutines.flow.*
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handle(command: C): Flow<E> =
     command
         .fetchEvents()
@@ -44,7 +42,6 @@ fun <C, S, E> EventSourcingAggregate<C, S, E>.handle(command: C): Flow<E> =
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handle(command: C): Flow<E> =
     command
         .fetchEvents()
@@ -59,7 +56,6 @@ fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handle(command: C): F
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimistically(command: C): Flow<Pair<E, V>> = flow {
     val events = command.fetchEvents()
     emitAll(
@@ -78,7 +74,6 @@ fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimistically(
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOptimistically(command: C): Flow<Pair<E, V>> =
     command
         .fetchEvents().map { it.first }
@@ -87,61 +82,49 @@ fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOp
 
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handle(commands: Flow<C>): Flow<E> =
     commands.flatMapConcat { handle(it) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E> EventSourcingOrchestratingAggregate<C, S, E>.handle(commands: Flow<C>): Flow<E> =
     commands.flatMapConcat { handle(it) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingAggregate<C, S, E, V>.handleOptimistically(commands: Flow<C>): Flow<Pair<E, V>> =
     commands.flatMapConcat { handleOptimistically(it) }
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, S, E, V> EventSourcingLockingOrchestratingAggregate<C, S, E, V>.handleOptimistically(commands: Flow<C>): Flow<Pair<E, V>> =
     commands.flatMapConcat { handleOptimistically(it) }
 
 
-@FlowPreview
 fun <C, E> C.publishTo(aggregate: EventSourcingAggregate<C, *, E>): Flow<E> =
     aggregate.handle(this)
 
-@FlowPreview
 fun <C, E, V> C.publishOptimisticallyTo(aggregate: EventSourcingLockingAggregate<C, *, E, V>): Flow<Pair<E, V>> =
     aggregate.handleOptimistically(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> C.publishTo(aggregate: EventSourcingOrchestratingAggregate<C, *, E>): Flow<E> =
     aggregate.handle(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> C.publishOptimisticallyTo(aggregate: EventSourcingLockingOrchestratingAggregate<C, *, E, V>): Flow<Pair<E, V>> =
     aggregate.handleOptimistically(this)
 
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> Flow<C>.publishTo(aggregate: EventSourcingAggregate<C, *, E>): Flow<E> =
     aggregate.handle(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> Flow<C>.publishOptimisticallyTo(aggregate: EventSourcingLockingAggregate<C, *, E, V>): Flow<Pair<E, V>> =
     aggregate.handleOptimistically(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E> Flow<C>.publishTo(aggregate: EventSourcingOrchestratingAggregate<C, *, E>): Flow<E> =
     aggregate.handle(this)
 
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <C, E, V> Flow<C>.publishOptimisticallyTo(aggregate: EventSourcingLockingOrchestratingAggregate<C, *, E, V>): Flow<Pair<E, V>> =
     aggregate.handleOptimistically(this)

--- a/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManagerExtension.kt
+++ b/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/SagaManagerExtension.kt
@@ -17,7 +17,6 @@
 package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapConcat
 
@@ -40,7 +39,6 @@ fun <AR, A> SagaManager<AR, A>.handle(actionResult: AR): Flow<A> = actionResult.
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <AR, A> SagaManager<AR, A>.handle(actionResults: Flow<AR>): Flow<A> = actionResults.flatMapConcat { handle(it) }
 
 /**
@@ -62,5 +60,4 @@ fun <AR, A> AR.publishTo(sagaManager: SagaManager<AR, A>): Flow<A> = sagaManager
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 fun <AR, A> Flow<AR>.publishTo(sagaManager: SagaManager<AR, A>): Flow<A> = sagaManager.handle(this)

--- a/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateExtension.kt
+++ b/application-vanilla/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateExtension.kt
@@ -16,7 +16,6 @@
 
 package com.fraktalio.fmodel.application
 
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -28,7 +27,6 @@ import kotlinx.coroutines.flow.map
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, I> I.handle(command: C): S where I : StateComputation<C, S, E>,
                                                        I : StateRepository<C, S> =
     command.fetchState().computeNewState(command).save()
@@ -41,7 +39,6 @@ suspend fun <C, S, E, I> I.handle(command: C): S where I : StateComputation<C, S
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, V, I> I.handleOptimistically(command: C): Pair<S, V> where I : StateComputation<C, S, E>,
                                                                                  I : StateLockingRepository<C, S, V> {
     val (state, version) = command.fetchState()
@@ -58,7 +55,6 @@ suspend fun <C, S, E, V, I> I.handleOptimistically(command: C): Pair<S, V> where
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, I> I.handle(commands: Flow<C>): Flow<S> where I : StateComputation<C, S, E>,
                                                             I : StateRepository<C, S> =
     commands.map { handle(it) }
@@ -71,7 +67,6 @@ fun <C, S, E, I> I.handle(commands: Flow<C>): Flow<S> where I : StateComputation
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V, I> I.handleOptimistically(commands: Flow<C>): Flow<Pair<S, V>> where I : StateComputation<C, S, E>,
                                                                                       I : StateLockingRepository<C, S, V> =
     commands.map { handleOptimistically(it) }
@@ -85,7 +80,6 @@ fun <C, S, E, V, I> I.handleOptimistically(commands: Flow<C>): Flow<Pair<S, V>> 
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, A> C.publishTo(aggregate: A): S where A : StateComputation<C, S, E>,
                                                             A : StateRepository<C, S> =
     aggregate.handle(this)
@@ -98,7 +92,6 @@ suspend fun <C, S, E, A> C.publishTo(aggregate: A): S where A : StateComputation
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 suspend fun <C, S, E, V, A> C.publishOptimisticallyTo(aggregate: A): Pair<S, V> where A : StateComputation<C, S, E>,
                                                                                       A : StateLockingRepository<C, S, V> =
     aggregate.handleOptimistically(this)
@@ -111,7 +104,6 @@ suspend fun <C, S, E, V, A> C.publishOptimisticallyTo(aggregate: A): Pair<S, V> 
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, A> Flow<C>.publishTo(aggregate: A): Flow<S> where A : StateComputation<C, S, E>,
                                                                 A : StateRepository<C, S> =
     aggregate.handle(this)
@@ -124,7 +116,6 @@ fun <C, S, E, A> Flow<C>.publishTo(aggregate: A): Flow<S> where A : StateComputa
  *
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
-@FlowPreview
 fun <C, S, E, V, A> Flow<C>.publishOptimisticallyTo(aggregate: A): Flow<Pair<S, V>> where A : StateComputation<C, S, E>,
                                                                                           A : StateLockingRepository<C, S, V> =
     aggregate.handleOptimistically(this)

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateTest.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateTest.kt
@@ -23,21 +23,18 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 
 /**
  * DSL - Given
  */
-@FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(repository: EventRepository<C, E>, command: () -> C): Flow<E> =
     EventSourcingAggregate(
         decider = this,
         eventRepository = repository
     ).handle(command())
 
-@FlowPreview
 private fun <C, S, E, V> IDecider<C, S, E>.given(
     repository: EventLockingRepository<C, E, V>,
     command: () -> C
@@ -47,7 +44,6 @@ private fun <C, S, E, V> IDecider<C, S, E>.given(
         eventRepository = repository
     ).handleOptimistically(command())
 
-@FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
     saga: ISaga<E, C>,
     repository: EventRepository<C, E>,
@@ -77,7 +73,6 @@ private suspend infix fun <E, V> Flow<Pair<E, V>>.thenEventPairs(expected: Itera
  * Event sourced aggregate test
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 class EventSourcedAggregateTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateTest.kt
@@ -19,19 +19,16 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 /**
  * DSL - Given
  */
-@FlowPreview
 private suspend fun <C, S, E> IDecider<C, S, E>.given(repository: StateRepository<C, S>, command: () -> C): S =
     StateStoredAggregate(
         decider = this,
         stateRepository = repository
     ).handle(command())
 
-@FlowPreview
 private suspend fun <C, S, E, V> IDecider<C, S, E>.given(
     repository: StateLockingRepository<C, S, V>,
     command: () -> C
@@ -57,7 +54,6 @@ private infix fun <S, V> Pair<S, V>.thenStateAndVersion(expected: Pair<S, V>) = 
  * State-stored aggregate test
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@FlowPreview
 class StateStoredAggregateTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberEventSourcedAggregate.kt
@@ -29,7 +29,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -42,7 +41,7 @@ import kotlinx.coroutines.FlowPreview
  * @param repository the event-sourcing repository for all (even and odd) numbers
  * @return the event-sourcing aggregate instance for all (even and odd) numbers
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun numberAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
+++ b/application-vanilla/src/commonTest/kotlin/com/fraktalio/fmodel/application/examples/numbers/NumberStateStoredAggregate.kt
@@ -29,7 +29,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.NumberEvent.OddNumberEvent
 import com.fraktalio.fmodel.domain.examples.numbers.api.OddNumberState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 
 
 /**
@@ -42,7 +41,7 @@ import kotlinx.coroutines.FlowPreview
  * @param repository the state-stored repository for all (even and odd) numbers
  * @return the state-stored aggregate instance for all (even and odd) numbers
  */
-@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 fun numberStateStoredAggregate(
     evenNumberDecider: Decider<EvenNumberCommand?, EvenNumberState, NumberEvent.EvenNumberEvent?>,
     oddNumberDecider: Decider<OddNumberCommand?, OddNumberState, OddNumberEvent?>,

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregateActorExtension.kt
@@ -2,7 +2,6 @@ package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -30,7 +29,6 @@ import kotlin.math.absoluteValue
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
     commands: Flow<C>,
     numberOfActors: Int = 100,
@@ -71,7 +69,6 @@ fun <C, S, E> EventSourcingAggregate<C, S, E>.handleConcurrently(
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <C, E> Flow<C>.publishConcurrentlyTo(
     aggregate: EventSourcingAggregate<C, *, E>,
     numberOfActors: Int = 100,

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorExtension.kt
@@ -18,7 +18,6 @@ package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -47,7 +46,6 @@ import kotlin.math.absoluteValue
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <S, E> MaterializedView<S, E>.handleConcurrently(
     events: Flow<E>,
     numberOfActors: Int = 100,
@@ -86,7 +84,6 @@ fun <S, E> MaterializedView<S, E>.handleConcurrently(
  * @author Иван Дугалић / Ivan Dugalic / @idugalic
  */
 @ObsoleteCoroutinesApi
-@FlowPreview
 @ExperimentalContracts
 fun <S, E> Flow<E>.publishConcurrentlyTo(
     materializedView: MaterializedView<S, E>,

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/SagaManagerActorExtension.kt
@@ -18,7 +18,6 @@ package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -46,7 +45,6 @@ import kotlin.math.absoluteValue
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <AR, A> SagaManager<AR, A>.handleConcurrently(
     actionResults: Flow<AR>,
     numberOfActors: Int = 100,
@@ -85,7 +83,6 @@ fun <AR, A> SagaManager<AR, A>.handleConcurrently(
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <AR, A> Flow<AR>.publishConcurrentlyTo(
     sagaManager: SagaManager<AR, A>,
     numberOfActors: Int = 100,

--- a/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
+++ b/application-vanilla/src/jvmMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorExtension.kt
@@ -18,7 +18,6 @@ package com.fraktalio.fmodel.application
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.SendChannel
@@ -46,7 +45,6 @@ import kotlin.math.absoluteValue
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <C, S, E> StateStoredAggregate<C, S, E>.handleConcurrently(
     commands: Flow<C>,
     numberOfActors: Int = 100,
@@ -85,7 +83,6 @@ fun <C, S, E> StateStoredAggregate<C, S, E>.handleConcurrently(
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 fun <C, S> Flow<C>.publishConcurrentlyTo(
     aggregate: StateStoredAggregate<C, S, *>,
     numberOfActors: Int = 100,

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/EventSourcedAggregateActorTest.kt
@@ -12,7 +12,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -24,7 +23,6 @@ import kotlin.contracts.ExperimentalContracts
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
     repository: EventRepository<C, E>,
     partitionKey: (C) -> Int,
@@ -54,7 +52,6 @@ private suspend infix fun <E> Flow<E>.thenEvents(expected: Collection<E>) = toLi
  */
 @OptIn(ObsoleteCoroutinesApi::class)
 @ExperimentalContracts
-@FlowPreview
 class EventSourcedAggregateActorTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val evenNumberRepository = evenNumberRepository() as EvenNumberRepository

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/MaterializedViewActorTest.kt
@@ -17,7 +17,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.odd.query.oddNumberView
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -28,7 +27,6 @@ import kotlin.contracts.ExperimentalContracts
  * DSL - Given
  */
 @ObsoleteCoroutinesApi
-@FlowPreview
 @ExperimentalContracts
 private fun <S, E> IView<S, E>.given(
     repository: ViewStateRepository<E, S>,
@@ -56,7 +54,6 @@ private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toLis
  * Materialized View Actor Test
  */
 @OptIn(ObsoleteCoroutinesApi::class)
-@FlowPreview
 @ExperimentalContracts
 class MaterializedViewActorTest : FunSpec({
     val evenView = evenNumberView()

--- a/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
+++ b/application-vanilla/src/jvmTest/kotlin/com/fraktalio/fmodel/application/StateStoredAggregateActorTest.kt
@@ -18,7 +18,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -30,7 +29,6 @@ import kotlin.contracts.ExperimentalContracts
  */
 @ObsoleteCoroutinesApi
 @ExperimentalContracts
-@FlowPreview
 private fun <C, S, E> IDecider<C, S, E>.given(
     repository: StateRepository<C, S>,
     partitionKey: (C) -> Int,
@@ -58,7 +56,6 @@ private suspend infix fun <S> Flow<S>.thenState(expected: Collection<S>) = toLis
  */
 @OptIn(ObsoleteCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 @ExperimentalContracts
-@FlowPreview
 class StateStoredAggregateActorTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/EventSourcingAggregate.kt
@@ -19,14 +19,12 @@ package com.fraktalio.fmodel.application
 import com.fraktalio.fmodel.domain.IDecider
 import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
 
 /**
  * `EventComputation` interface formalizes the `Event Computation` algorithm / event sourced system by using a `decider` of type [IDecider]<[C], [S], [E]> to handle commands based on the current events, and produce new events.
  */
 interface EventComputation<C, S, E> : IDecider<C, S, E> {
-    @FlowPreview
     fun Flow<E>.computeNewEvents(command: C): Flow<E> = flow {
         val currentState = fold(initialState) { s, e -> evolve(s, e) }
         val resultingEvents = decide(command, currentState)
@@ -40,7 +38,6 @@ interface EventComputation<C, S, E> : IDecider<C, S, E> {
  */
 interface EventOrchestratingComputation<C, S, E> : ISaga<E, C>, IDecider<C, S, E> {
     @ExperimentalCoroutinesApi
-    @FlowPreview
     fun Flow<E>.computeNewEventsByOrchestrating(command: C, fetchEvents: (C) -> Flow<E>): Flow<E> = flow {
         val currentState = fold(initialState) { s, e -> evolve(s, e) }
         var resultingEvents = decide(command, currentState)

--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
@@ -19,7 +19,6 @@ package com.fraktalio.fmodel.application
 import com.fraktalio.fmodel.domain.IDecider
 import com.fraktalio.fmodel.domain.ISaga
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.fold
@@ -35,7 +34,6 @@ interface StateComputation<C, S, E> : IDecider<C, S, E> {
      * @param command of type [C]
      * @return The newly computed state of type [S]
      */
-    @FlowPreview
     suspend fun S?.computeNewState(command: C): S {
         val currentState = this ?: initialState
         val events = decide(command, currentState)
@@ -96,7 +94,6 @@ interface StateOrchestratingComputation<C, S, E> : ISaga<E, C>, StateComputation
      * @return The newly computed state of type [S]
      */
     @ExperimentalCoroutinesApi
-    @FlowPreview
     override suspend fun S?.computeNewState(command: C): S {
         val currentState = this ?: initialState
         val events = decide(command, currentState)

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Decider.kt
@@ -20,7 +20,6 @@ import com.fraktalio.fmodel.domain.internal.InternalDecider
 import com.fraktalio.fmodel.domain.internal.asDecider
 import com.fraktalio.fmodel.domain.internal.combine
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
@@ -141,7 +140,6 @@ data class Decider<in C, S, E>(
  * @return [Decider]<[C_SUPER], [Pair]<[S], [S2]>, [E_SUPER]>
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 inline infix fun <reified C : C_SUPER, S, reified E : E_SUPER, reified C2 : C_SUPER, S2, reified E2 : E_SUPER, C_SUPER, E_SUPER> Decider<C?, S, E?>.combine(
     y: Decider<C2?, S2, E2?>
 ): Decider<C_SUPER?, Pair<S, S2>, E_SUPER?> =

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Saga.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/Saga.kt
@@ -17,7 +17,6 @@
 package com.fraktalio.fmodel.domain
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
@@ -154,7 +153,6 @@ data class Saga<in AR, out A>(
  * @return new Saga of type `[Saga]<[AR_SUPER], [A_SUPER]>`
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 inline infix fun <reified AR : AR_SUPER, A : A_SUPER, reified AR2 : AR_SUPER, A2 : A_SUPER, AR_SUPER, A_SUPER> Saga<AR?, A>.combine(
     y: Saga<AR2?, A2>
 ): Saga<AR_SUPER, A_SUPER> {

--- a/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/internal/InternalDecider.kt
+++ b/domain/src/commonMain/kotlin/com/fraktalio/fmodel/domain/internal/InternalDecider.kt
@@ -2,7 +2,6 @@ package com.fraktalio.fmodel.domain.internal
 
 import com.fraktalio.fmodel.domain.Decider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.flowOf
@@ -135,7 +134,6 @@ internal data class InternalDecider<in C, in Si, out So, in Ei, out Eo>(
  * @return new decider of type [InternalDecider]<[C], [Si], [Son], [Ei], [Eo]>
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.applyOnState(
     ff: InternalDecider<C, Si, (So) -> Son, Ei, Eo>
 ): InternalDecider<C, Si, Son, Ei, Eo> = InternalDecider(
@@ -158,7 +156,6 @@ internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.applyOn
  * @return new decider of type [InternalDecider]<[C], [Si], [Pair]<[So], [Son]>, [Ei], [Eo]>
  */
 @ExperimentalCoroutinesApi
-@FlowPreview
 @PublishedApi
 internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.productOnState(
     fb: InternalDecider<C, Si, Son, Ei, Eo>
@@ -193,7 +190,6 @@ internal fun <C, Si, So, Ei, Eo, Son> InternalDecider<C, Si, So, Ei, Eo>.product
 
 @ExperimentalCoroutinesApi
 @PublishedApi
-@FlowPreview
 internal inline infix fun <reified C : C_SUPER, Si, So, reified Ei : Ei_SUPER, Eo : Eo_SUPER, reified C2 : C_SUPER, Si2, So2, reified Ei2 : Ei_SUPER, Eo2 : Eo_SUPER, C_SUPER, Ei_SUPER, Eo_SUPER> InternalDecider<C?, Si, So, Ei?, Eo?>.combine(
     y: InternalDecider<C2?, Si2, So2, Ei2?, Eo2?>
 ): InternalDecider<C_SUPER?, Pair<Si, Si2>, Pair<So, So2>, Ei_SUPER, Eo_SUPER?> {

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/DeciderTest.kt
@@ -19,7 +19,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.flow.toList
@@ -42,7 +41,6 @@ private suspend infix fun <E> Flow<E>.thenEvents(expected: Iterable<E>) = toList
 private infix fun <S, U : S> S.thenState(expected: U?) = shouldBe(expected)
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@FlowPreview
 class DeciderTest : FunSpec({
     val evenDecider = evenNumberDecider()
     val oddDecider = oddNumberDecider()

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/SagaTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/SagaTest.kt
@@ -12,7 +12,6 @@ import com.fraktalio.fmodel.domain.examples.numbers.oddNumberSaga
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 
@@ -20,7 +19,6 @@ private fun <AR, A> ISaga<AR, A>.whenActionResult(actionResults: AR) = react(act
 private suspend infix fun <A> Flow<A>.expectActions(expected: Iterable<A>) = toList() shouldContainExactly (expected)
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@FlowPreview
 class SagaTest : FunSpec({
     val evenSaga = evenNumberSaga()
     val oddSaga = oddNumberSaga()

--- a/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/ViewTest.kt
+++ b/domain/src/commonTest/kotlin/com/fraktalio/fmodel/domain/ViewTest.kt
@@ -10,14 +10,12 @@ import com.fraktalio.fmodel.domain.examples.numbers.even.query.evenNumberView
 import com.fraktalio.fmodel.domain.examples.numbers.odd.query.oddNumberView
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.FlowPreview
 
 private fun <S, E> IView<S, E>.givenEvents(events: Iterable<E>) =
     events.fold(initialState) { s, e -> evolve(s, e) }
 
 private infix fun <S, U : S> S.thenState(expected: U?) = shouldBe(expected)
 
-@FlowPreview
 class ViewTest : FunSpec({
     val evenView = evenNumberView()
     val oddView = oddNumberView()


### PR DESCRIPTION
Promote the `@FlowPreview` API to stable/experimental, by removing the `@FlowPreview` in favor of `@ExperimentalCoroutinesApi`

read more here: [https://github.com/Kotlin/kotlinx.coroutines/pull/3548](https://github.com/Kotlin/kotlinx.coroutines/pull/3548)