### PR TITLE
Binary compatibility validator configured

### DIFF
--- a/application-arrow/api/application-arrow.api
+++ b/application-arrow/api/application-arrow.api
@@ -1,0 +1,52 @@
+public final class com/fraktalio/fmodel/application/EventSourcingAggregateArrowExtensionKt {
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedViewArrowExtensionKt {
+	public static final fun handleOptimisticallyWithDeduplicationWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/Pair;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimisticallyWithDeduplicationWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithDeduplicationWithEffect (Lkotlin/Pair;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyWithDeduplicationWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/SagaManagerArrowExtensionKt {
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/SagaManager;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/SagaManager;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/SagaManager;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/SagaManager;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredAggregateArrowExtensionKt {
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/StateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimisticallyWithEffect (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/StateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleWithEffect (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/StateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishWithEffect (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/StateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishWithEffect (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;)Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/application-vanilla/api/application-vanilla.api
+++ b/application-vanilla/api/application-vanilla.api
@@ -1,0 +1,100 @@
+public final class com/fraktalio/fmodel/application/EventSourcingAggregateActorExtensionKt {
+	public static final fun handleConcurrently (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleConcurrently (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrently$default (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrently$default (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleConcurrentlyAndOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleConcurrentlyAndOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrentlyAndOptimistically$default (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrentlyAndOptimistically$default (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyAndOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyAndOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyAndOptimisticallyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyAndOptimisticallyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingAggregateExtensionKt {
+	public static final fun handle (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingAggregate;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedViewActorExtensionKt {
+	public static final fun handleConcurrently (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrently$default (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleConcurrentlyAndOptimistically (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrentlyAndOptimistically$default (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyAndOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyAndOptimisticallyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedViewExtensionKt {
+	public static final fun handle (Lcom/fraktalio/fmodel/application/ViewStateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/ViewStateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimisticallyWithDeduplication (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/Pair;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimisticallyWithDeduplication (Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyWithDeduplicationTo (Lkotlin/Pair;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyWithDeduplicationTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/ViewStateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/ViewStateComputation;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/SagaManagerActorExtensionKt {
+	public static final fun handleConcurrently (Lcom/fraktalio/fmodel/application/SagaManager;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrently$default (Lcom/fraktalio/fmodel/application/SagaManager;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/SagaManager;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/SagaManager;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/SagaManagerExtensionKt {
+	public static final fun handle (Lcom/fraktalio/fmodel/application/SagaManager;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/SagaManager;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/SagaManager;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/SagaManager;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredAggregateActorExtensionKt {
+	public static final fun handleConcurrently (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrently$default (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleConcurrentlyAndOptimistically (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun handleConcurrentlyAndOptimistically$default (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyAndOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyAndOptimisticallyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishConcurrentlyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun publishConcurrentlyTo$default (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;IILkotlinx/coroutines/CoroutineStart;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredAggregateExtensionKt {
+	public static final fun handle (Lcom/fraktalio/fmodel/application/StateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handle (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/StateComputation;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun handleOptimistically (Lcom/fraktalio/fmodel/application/StateComputation;Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishOptimisticallyTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/StateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishOptimisticallyTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun publishTo (Ljava/lang/Object;Lcom/fraktalio/fmodel/application/StateComputation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun publishTo (Lkotlinx/coroutines/flow/Flow;Lcom/fraktalio/fmodel/application/StateComputation;)Lkotlinx/coroutines/flow/Flow;
+}
+

--- a/application/api/application.api
+++ b/application/api/application.api
@@ -1,0 +1,350 @@
+public abstract interface class com/fraktalio/fmodel/application/ActionPublisher {
+	public abstract fun publish (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract class com/fraktalio/fmodel/application/Error : com/fraktalio/fmodel/application/Result {
+	public abstract fun getThrowable ()Ljava/lang/Throwable;
+}
+
+public final class com/fraktalio/fmodel/application/Error$ActionResultHandlingFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$ActionResultHandlingFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$ActionResultHandlingFailed;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$ActionResultHandlingFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActionResult ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$ActionResultPublishingFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$ActionResultPublishingFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$ActionResultPublishingFailed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$ActionResultPublishingFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$CalculatingNewStateFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$CalculatingNewStateFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$CalculatingNewStateFailed;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$CalculatingNewStateFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Ljava/lang/Object;
+	public final fun getState ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$CalculatingNewViewStateFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$CalculatingNewViewStateFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$CalculatingNewViewStateFailed;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$CalculatingNewViewStateFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvent ()Ljava/lang/Object;
+	public final fun getState ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$CommandHandlingFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$CommandHandlingFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$CommandHandlingFailed;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$CommandHandlingFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$CommandPublishingFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$CommandPublishingFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$CommandPublishingFailed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$CommandPublishingFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$EventPublishingFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$EventPublishingFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$EventPublishingFailed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$EventPublishingFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$FetchingStateFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$FetchingStateFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$FetchingStateFailed;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$FetchingStateFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommand ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$FetchingViewStateFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$FetchingViewStateFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$FetchingViewStateFailed;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$FetchingViewStateFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvent ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/application/Error$StoringStateFailed : com/fraktalio/fmodel/application/Error {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lcom/fraktalio/fmodel/application/Error$StoringStateFailed;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/application/Error$StoringStateFailed;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/fraktalio/fmodel/application/Error$StoringStateFailed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getState ()Ljava/lang/Object;
+	public fun getThrowable ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventComputation : com/fraktalio/fmodel/domain/IDecider {
+	public abstract fun computeNewEvents (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/EventComputation$DefaultImpls {
+	public static fun computeNewEvents (Lcom/fraktalio/fmodel/application/EventComputation;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventLockingRepository {
+	public abstract fun fetchEvents (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getLatestVersionProvider ()Lkotlin/jvm/functions/Function1;
+	public abstract fun save (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun save (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventOrchestratingComputation : com/fraktalio/fmodel/domain/IDecider, com/fraktalio/fmodel/domain/ISaga {
+	public abstract fun computeNewEventsByOrchestrating (Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/EventOrchestratingComputation$DefaultImpls {
+	public static fun computeNewEventsByOrchestrating (Lcom/fraktalio/fmodel/application/EventOrchestratingComputation;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventRepository {
+	public abstract fun fetchEvents (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public abstract fun save (Lkotlinx/coroutines/flow/Flow;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventSourcingAggregate : com/fraktalio/fmodel/application/EventComputation, com/fraktalio/fmodel/application/EventRepository {
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingAggregate$DefaultImpls {
+	public static fun computeNewEvents (Lcom/fraktalio/fmodel/application/EventSourcingAggregate;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingAggregateKt {
+	public static final fun EventSourcingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventRepository;)Lcom/fraktalio/fmodel/application/EventSourcingAggregate;
+	public static final fun EventSourcingLockingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventLockingRepository;)Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;
+	public static final fun EventSourcingLockingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventLockingRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;
+	public static final fun EventSourcingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;
+	public static final fun eventSourcingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventRepository;)Lcom/fraktalio/fmodel/application/EventSourcingAggregate;
+	public static final fun eventSourcingLockingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventLockingRepository;)Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;
+	public static final fun eventSourcingLockingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventLockingRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;
+	public static final fun eventSourcingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/EventRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventSourcingLockingAggregate : com/fraktalio/fmodel/application/EventComputation, com/fraktalio/fmodel/application/EventLockingRepository {
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingLockingAggregate$DefaultImpls {
+	public static fun computeNewEvents (Lcom/fraktalio/fmodel/application/EventSourcingLockingAggregate;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate : com/fraktalio/fmodel/application/EventLockingRepository, com/fraktalio/fmodel/application/EventOrchestratingComputation {
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate$DefaultImpls {
+	public static fun computeNewEventsByOrchestrating (Lcom/fraktalio/fmodel/application/EventSourcingLockingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate : com/fraktalio/fmodel/application/EventOrchestratingComputation, com/fraktalio/fmodel/application/EventRepository {
+}
+
+public final class com/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate$DefaultImpls {
+	public static fun computeNewEventsByOrchestrating (Lcom/fraktalio/fmodel/application/EventSourcingOrchestratingAggregate;Lkotlinx/coroutines/flow/Flow;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/MaterializedLockingDeduplicationView : com/fraktalio/fmodel/application/ViewStateComputation, com/fraktalio/fmodel/application/ViewStateLockingDeduplicationRepository {
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedLockingDeduplicationView$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/MaterializedLockingDeduplicationView;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/MaterializedLockingView : com/fraktalio/fmodel/application/ViewStateComputation, com/fraktalio/fmodel/application/ViewStateLockingRepository {
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedLockingView$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/MaterializedLockingView;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/MaterializedView : com/fraktalio/fmodel/application/ViewStateComputation, com/fraktalio/fmodel/application/ViewStateRepository {
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedView$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/MaterializedView;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/application/MaterializedViewKt {
+	public static final fun MaterializedLockingDeduplicationView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateLockingDeduplicationRepository;)Lcom/fraktalio/fmodel/application/MaterializedLockingDeduplicationView;
+	public static final fun MaterializedLockingView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateLockingRepository;)Lcom/fraktalio/fmodel/application/MaterializedLockingView;
+	public static final fun MaterializedView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateRepository;)Lcom/fraktalio/fmodel/application/MaterializedView;
+	public static final fun materializedLockingDeduplicationView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateLockingDeduplicationRepository;)Lcom/fraktalio/fmodel/application/MaterializedLockingDeduplicationView;
+	public static final fun materializedLockingView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateLockingRepository;)Lcom/fraktalio/fmodel/application/MaterializedLockingView;
+	public static final fun materializedView (Lcom/fraktalio/fmodel/domain/IView;Lcom/fraktalio/fmodel/application/ViewStateRepository;)Lcom/fraktalio/fmodel/application/MaterializedView;
+}
+
+public abstract class com/fraktalio/fmodel/application/Result {
+}
+
+public abstract interface class com/fraktalio/fmodel/application/SagaManager : com/fraktalio/fmodel/application/ActionPublisher, com/fraktalio/fmodel/domain/ISaga {
+	public abstract fun computeNewActions (Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/SagaManager$DefaultImpls {
+	public static fun computeNewActions (Lcom/fraktalio/fmodel/application/SagaManager;Ljava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class com/fraktalio/fmodel/application/SagaManagerKt {
+	public static final fun SagaManager (Lcom/fraktalio/fmodel/domain/ISaga;Lcom/fraktalio/fmodel/application/ActionPublisher;)Lcom/fraktalio/fmodel/application/SagaManager;
+	public static final fun sagaManager (Lcom/fraktalio/fmodel/domain/ISaga;Lcom/fraktalio/fmodel/application/ActionPublisher;)Lcom/fraktalio/fmodel/application/SagaManager;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateComputation : com/fraktalio/fmodel/domain/IDecider {
+	public abstract fun computeNewState (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/application/StateComputation$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateComputation;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateLockingRepository {
+	public abstract fun fetchState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateOrchestratingComputation : com/fraktalio/fmodel/application/StateComputation, com/fraktalio/fmodel/domain/ISaga {
+	public abstract fun computeNewState (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/application/StateOrchestratingComputation$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateOrchestratingComputation;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateRepository {
+	public abstract fun fetchState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateStoredAggregate : com/fraktalio/fmodel/application/StateComputation, com/fraktalio/fmodel/application/StateRepository {
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredAggregate$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateStoredAggregate;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredAggregateKt {
+	public static final fun StateStoredAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateRepository;)Lcom/fraktalio/fmodel/application/StateStoredAggregate;
+	public static final fun StateStoredLockingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateLockingRepository;)Lcom/fraktalio/fmodel/application/StateStoredLockingAggregate;
+	public static final fun StateStoredLockingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateLockingRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/StateStoredLockingOrchestratingAggregate;
+	public static final fun StateStoredOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/StateStoredOrchestratingAggregate;
+	public static final fun stateStoredAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateRepository;)Lcom/fraktalio/fmodel/application/StateStoredAggregate;
+	public static final fun stateStoredLockingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateLockingRepository;)Lcom/fraktalio/fmodel/application/StateStoredLockingAggregate;
+	public static final fun stateStoredLockingOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateLockingRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/StateStoredLockingOrchestratingAggregate;
+	public static final fun stateStoredOrchestratingAggregate (Lcom/fraktalio/fmodel/domain/IDecider;Lcom/fraktalio/fmodel/application/StateRepository;Lcom/fraktalio/fmodel/domain/ISaga;)Lcom/fraktalio/fmodel/application/StateStoredOrchestratingAggregate;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateStoredLockingAggregate : com/fraktalio/fmodel/application/StateComputation, com/fraktalio/fmodel/application/StateLockingRepository {
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredLockingAggregate$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateStoredLockingAggregate;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateStoredLockingOrchestratingAggregate : com/fraktalio/fmodel/application/StateLockingRepository, com/fraktalio/fmodel/application/StateOrchestratingComputation {
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredLockingOrchestratingAggregate$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateStoredLockingOrchestratingAggregate;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/StateStoredOrchestratingAggregate : com/fraktalio/fmodel/application/StateOrchestratingComputation, com/fraktalio/fmodel/application/StateRepository {
+}
+
+public final class com/fraktalio/fmodel/application/StateStoredOrchestratingAggregate$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/StateStoredOrchestratingAggregate;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/ViewStateComputation : com/fraktalio/fmodel/domain/IView {
+	public abstract fun computeNewState (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/application/ViewStateComputation$DefaultImpls {
+	public static fun computeNewState (Lcom/fraktalio/fmodel/application/ViewStateComputation;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/ViewStateLockingDeduplicationRepository {
+	public abstract fun fetchState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/ViewStateLockingRepository {
+	public abstract fun fetchState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/application/ViewStateRepository {
+	public abstract fun fetchState (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun save (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     base
     id("maven-publish")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.13.2"
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.kotest.multiplatform) apply false
     alias(libs.plugins.dokka)

--- a/domain/api/domain.api
+++ b/domain/api/domain.api
@@ -1,0 +1,135 @@
+public final class com/fraktalio/fmodel/domain/Decider : com/fraktalio/fmodel/domain/IDecider {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)Lcom/fraktalio/fmodel/domain/Decider;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/domain/Decider;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;ILjava/lang/Object;)Lcom/fraktalio/fmodel/domain/Decider;
+	public final fun dimapOnEvent (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Decider;
+	public final fun dimapOnState (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Decider;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDecide ()Lkotlin/jvm/functions/Function2;
+	public fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public fun getInitialState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun mapLeftOnCommand (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Decider;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/domain/DeciderBuilder {
+	public final fun build ()Lcom/fraktalio/fmodel/domain/Decider;
+	public final fun decide (Lkotlin/jvm/functions/Function2;)V
+	public final fun evolve (Lkotlin/jvm/functions/Function2;)V
+	public final fun initialState (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/fraktalio/fmodel/domain/DeciderKt {
+	public static final fun decider (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Decider;
+}
+
+public abstract interface class com/fraktalio/fmodel/domain/IDecider {
+	public abstract fun getDecide ()Lkotlin/jvm/functions/Function2;
+	public abstract fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public abstract fun getInitialState ()Ljava/lang/Object;
+}
+
+public abstract interface class com/fraktalio/fmodel/domain/ISaga {
+	public abstract fun getReact ()Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class com/fraktalio/fmodel/domain/IView {
+	public abstract fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public abstract fun getInitialState ()Ljava/lang/Object;
+}
+
+public final class com/fraktalio/fmodel/domain/Saga : com/fraktalio/fmodel/domain/ISaga {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Saga;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/domain/Saga;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/fraktalio/fmodel/domain/Saga;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getReact ()Lkotlin/jvm/functions/Function1;
+	public fun hashCode ()I
+	public final fun mapLeftOnActionResult (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Saga;
+	public final fun mapOnAction (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Saga;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/domain/SagaKt {
+	public static final fun saga (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/Saga;
+}
+
+public final class com/fraktalio/fmodel/domain/View : com/fraktalio/fmodel/domain/IView {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)Lcom/fraktalio/fmodel/domain/View;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/domain/View;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;ILjava/lang/Object;)Lcom/fraktalio/fmodel/domain/View;
+	public final fun dimapOnState (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/View;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public fun getInitialState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun mapLeftOnEvent (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/View;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/domain/ViewBuilder {
+	public final fun build ()Lcom/fraktalio/fmodel/domain/View;
+	public final fun evolve (Lkotlin/jvm/functions/Function2;)V
+	public final fun initialState (Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class com/fraktalio/fmodel/domain/ViewKt {
+	public static final fun view (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/View;
+}
+
+public final class com/fraktalio/fmodel/domain/internal/InternalDecider {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Lkotlin/jvm/functions/Function2;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/domain/internal/InternalDecider;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;ILjava/lang/Object;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun dimapOnEvent (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun dimapOnState (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDecide ()Lkotlin/jvm/functions/Function2;
+	public final fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public final fun getInitialState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun mapLeftOnCommand (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun mapLeftOnEvent (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun mapLeftOnState (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun mapOnEvent (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public final fun mapOnState (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/domain/internal/InternalDeciderKt {
+	public static final fun asDecider (Lcom/fraktalio/fmodel/domain/internal/InternalDecider;)Lcom/fraktalio/fmodel/domain/Decider;
+	public static final fun productOnState (Lcom/fraktalio/fmodel/domain/internal/InternalDecider;Lcom/fraktalio/fmodel/domain/internal/InternalDecider;)Lcom/fraktalio/fmodel/domain/internal/InternalDecider;
+}
+
+public final class com/fraktalio/fmodel/domain/internal/InternalView {
+	public fun <init> (Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)V
+	public final fun component1 ()Lkotlin/jvm/functions/Function2;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Lkotlin/jvm/functions/Function2;Ljava/lang/Object;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public static synthetic fun copy$default (Lcom/fraktalio/fmodel/domain/internal/InternalView;Lkotlin/jvm/functions/Function2;Ljava/lang/Object;ILjava/lang/Object;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public final fun dimapOnState (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvolve ()Lkotlin/jvm/functions/Function2;
+	public final fun getInitialState ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun mapLeftOnEvent (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public final fun mapLeftOnState (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public final fun mapOnState (Lkotlin/jvm/functions/Function1;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/fraktalio/fmodel/domain/internal/InternalViewKt {
+	public static final fun asView (Lcom/fraktalio/fmodel/domain/internal/InternalView;)Lcom/fraktalio/fmodel/domain/View;
+	public static final fun productOnState (Lcom/fraktalio/fmodel/domain/internal/InternalView;Lcom/fraktalio/fmodel/domain/internal/InternalView;)Lcom/fraktalio/fmodel/domain/internal/InternalView;
+}
+


### PR DESCRIPTION
Allows dumping binary API of a JVM part of a Kotlin library that is public in the sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

[https://github.com/Kotlin/binary-compatibility-validator](https://github.com/Kotlin/binary-compatibility-validator)
