### PR TITLE
Conforming to new default hierarchy template for setting up multiplatform projects

### DIFF
--- a/application-arrow/build.gradle.kts
+++ b/application-arrow/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
     macosX64()
     macosArm64()
 
-    tvos()
     tvosSimulatorArm64()
 
     watchosArm32()
@@ -36,20 +35,20 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(libs.coroutines.core)
                 api(libs.arrow.core)
                 api(projects.application)
             }
         }
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(libs.kotest.frameworkEngine)
                 implementation(libs.kotest.assertionsCore)
             }
         }
-        val jvmTest by getting {
+        jvmTest {
             dependencies {
                 runtimeOnly(libs.kotest.runnerJUnit5)
             }

--- a/application-vanilla/build.gradle.kts
+++ b/application-vanilla/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
     macosX64()
     macosArm64()
 
-    tvos()
     tvosSimulatorArm64()
 
     watchosArm32()
@@ -36,20 +35,20 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(libs.coroutines.core)
                 api(projects.application)
             }
         }
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(libs.kotest.frameworkEngine)
                 implementation(libs.kotest.assertionsCore)
             }
         }
 
-        val jvmTest by getting {
+        jvmTest {
             dependencies {
                 runtimeOnly(libs.kotest.runnerJUnit5)
             }

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
     macosX64()
     macosArm64()
 
-    tvos()
     tvosSimulatorArm64()
 
     watchosArm32()
@@ -35,7 +34,7 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(libs.coroutines.core)
                 api(projects.domain)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -23,7 +23,6 @@ kotlin {
     macosX64()
     macosArm64()
 
-    tvos()
     tvosSimulatorArm64()
 
     watchosArm32()
@@ -36,18 +35,18 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 implementation(libs.coroutines.core)
             }
         }
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(libs.kotest.frameworkEngine)
                 implementation(libs.kotest.assertionsCore)
             }
         }
-        val jvmTest by getting {
+        jvmTest {
             dependencies {
                 runtimeOnly(libs.kotest.runnerJUnit5)
             }


### PR DESCRIPTION
Conforming to new default hierarchy template for setting up multiplatform projects.

1. Source sets are statically resolved now:

From
```
sourceSets {
        val commonMain by getting {
            dependencies {
                implementation(libs.coroutines.core)
                api(libs.arrow.core)
                api(projects.application)
            }
        }
```
To
```
 sourceSets {
        commonMain {
            dependencies {
                implementation(libs.coroutines.core)
            }
        }
```

2. `tvos` target removed as depricated
