### PR TITLE
Kotlin upgraded to 2.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ coroutines = "1.8.1"
 dokka = "1.9.20"
 kotest = "5.9.0"
 kotest-plugin = "5.9.0"
-kotlin = "1.9.24"
+kotlin = "2.0.0-RC2"
 arrow = "1.2.4"
 
 [libraries]


### PR DESCRIPTION
- release candidate RC2

Make sure to `enable K2 Kotlin mode` in your IntelliJ IDEA