### PR TITLE
Fix orchestrated/recursive state computation to ensure proper state updates

### DIFF
--- a/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
+++ b/application/src/commonMain/kotlin/com/fraktalio/fmodel/application/StateStoredAggregate.kt
@@ -97,8 +97,10 @@ interface StateOrchestratingComputation<C, S, E> : ISaga<E, C>, StateComputation
     override suspend fun S?.computeNewState(command: C): S {
         val currentState = this ?: initialState
         val events = decide(command, currentState)
-        val newState = events.fold(currentState) { s, e -> evolve(s, e) }
-        events.flatMapConcat { react(it) }.onEach { newState.computeNewState(it) }.collect()
+        var newState = events.fold(currentState) { s, e -> evolve(s, e) }
+        events.flatMapConcat { react(it) }.collect {
+            newState = newState.computeNewState(it)
+        }
         return newState
     }
 }


### PR DESCRIPTION
This development fixes a bug in which the orchestrated state computation (with sagas) did not return the very last state computation but the state after the first computation/decision-making.

In summary, the state computation was successfully performed, but the result was never returned.